### PR TITLE
cps: strip types from call nodes and their arguments

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -813,15 +813,17 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
 proc workaroundRewrites(n: NimNode): NimNode =
   proc workaroundSigmatchSkip(n: NimNode): NimNode =
     if n.kind in nnkCallKinds:
-      # We recreate the arguments nodes here, to set their .typ to nil
+      # We recreate the nodes here, to set their .typ to nil
       # so that sigmatch doesn't decide to skip it
-      result = n
-      for i in 1..<result.len:
-        if result[i].kind notin AtomicNodes:
-          var arg = newNimNode(result[i].kind, result[i])
-          for child in result[i].items:
-            arg.add child
-          result[i] = arg
+      result = newNimNode(n.kind, n)
+      for child in n.items:
+        if child.kind notin AtomicNodes:
+          var newChild = newNimNode(child.kind, child)
+          for grandchild in child.items:
+            newChild.add workaroundRewrites grandchild
+          result.add newChild
+        else:
+          result.add child
 
   result = filter(n, workaroundSigmatchSkip)
 

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -556,22 +556,19 @@ testes:
 
   block:
     ## while statement with local var inside
-    when true:
-      skip"pending nim-lang/Nim#16719"
-    else:
-      r = 0
-      proc foo() {.cps: Cont.} =
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      var i = 0
+      while i < 2:
         inc r
-        var i = 0
-        while i < 2:
-          inc r
-          let x = i
-          noop()
-          inc r
-          inc i
-          noop()
-          inc r
-          check x == i - 1
+        let x = i
+        noop()
         inc r
-      trampoline foo()
-      check r == 8
+        inc i
+        noop()
+        inc r
+        check x == i - 1
+      inc r
+    trampoline foo()
+    check r == 8


### PR DESCRIPTION
Expand workaroundRewrites to strip types out of the call, and recurse
into its arguments.

This is a walkaround for nim-lang/Nim#16719.

Fixes "while statement with local var inside" test.