### PR TITLE
cps: add support for function pointer calls

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -26,12 +26,28 @@ when defined(yourdaywillcomelittleonecommayourdaywillcomedotdotdot):
   const
     cpsish = {nnkYieldStmt, nnkContinueStmt}  ## precede cps calls
 
+func getCallSym(n: NimNode): NimNode =
+  ## Get the symbol that is being called
+  expectKind n, callish
+  result = n[0]
+  while result != nil:
+    case result.kind
+    of nnkDotExpr:
+      result = result[1]
+    of nnkSym:
+      break
+    of nnkIdent:
+      raise newException(CatchableError, "This call is not typed")
+    else:
+      assert false, "unknown node type: " & $result.kind
+  assert not result.isNil
+
 proc isCpsCall(n: NimNode): bool =
   ## true if this node holds a call to a cps procedure
   assert not n.isNil
   if len(n) > 0:
     if n.kind in callish:
-      let p = n[0].getImpl
+      let p = n.getCallSym.getImpl
       result = p.hasPragma("cpsCall")
 
 proc firstReturn(p: NimNode): NimNode =

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -572,3 +572,17 @@ testes:
       inc r
     trampoline foo()
     check r == 8
+
+  block:
+    ## running a function pointer inside an object
+    when true:
+      skip "pending nim-lang/Nim#17836"
+    else:
+      type Fn = object
+        fn: proc(i: int): int
+      let fn = Fn(fn: proc(i: int): int = i * 2)
+
+      proc foo() {.cps: Cont.} =
+        check fn.fn(10) == 20
+
+      trampoline foo()


### PR DESCRIPTION
isCpsCall assumes that the callee is always a nnkSym, which is not the
case when the callee is a function pointer stored inside an object.

Blocked by nim-lang/Nim#17836, but confirmed working with @saem
workaround.