### PR TITLE
cps: strip more call nodes types

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -833,13 +833,14 @@ proc workaroundRewrites(n: NimNode): NimNode =
       # so that sigmatch doesn't decide to skip it
       result = newNimNode(n.kind, n)
       for child in n.items:
+        var newChild = workaroundRewrites child
+        # The containers of direct children always has to be rewritten
         if child.kind notin AtomicNodes:
-          var newChild = newNimNode(child.kind, child)
-          for grandchild in child.items:
-            newChild.add workaroundRewrites grandchild
-          result.add newChild
-        else:
-          result.add child
+          let rewritten = newNimNode(newChild.kind, newChild)
+          for grandchild in newChild.items:
+            rewritten.add grandchild
+          newChild = rewritten
+        result.add newChild
 
   result = filter(n, workaroundSigmatchSkip)
 

--- a/cps.nim
+++ b/cps.nim
@@ -835,6 +835,7 @@ proc workaroundRewrites(n: NimNode): NimNode =
       for child in n.items:
         var newChild = workaroundRewrites child
         # The containers of direct children always has to be rewritten
+        # since they also have a .typ attached from the previous sem pass
         if child.kind notin AtomicNodes:
           let rewritten = newNimNode(newChild.kind, newChild)
           for grandchild in newChild.items:

--- a/cps.nim
+++ b/cps.nim
@@ -846,7 +846,9 @@ proc workaroundRewrites(n: NimNode): NimNode =
       for child in n.items:
         # The containers of direct children always has to be rewritten
         # since they also have a .typ attached from the previous sem pass
-        result.add rewriteContainer workaroundRewrites child
+        result.add:
+          rewriteContainer:
+            workaroundRewrites child
 
   result = filter(n, workaroundSigmatchSkip)
 

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -617,3 +617,18 @@ testes:
 
       trampoline foo()
       check r == 2
+
+  block:
+    ## template call in nested call nodes
+    r = 0
+
+    template nestedStr(): string =
+      var s = "foo"
+      s
+
+    proc foo() {.cps: Cont.} =
+      inc r
+      check not(nestedStr != "foo")
+
+    trampoline foo()
+    check r == 1

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -622,13 +622,28 @@ testes:
     ## template call in nested call nodes
     r = 0
 
-    template nestedStr(): string =
-      var s = "foo"
-      s
+    # It is crucial that none of these templates call any other templates/macros.
+    template negate(b: untyped): untyped =
+      not b
+
+    template isEmpty(s: untyped): untyped =
+      s == ""
+
+    template makeStr(s: untyped): untyped =
+      let r = $s
+      r
 
     proc foo() {.cps: Cont.} =
       inc r
-      check not(nestedStr != "foo")
+      # It has to have this exact amount of templates nesting or it won't
+      # reproduce the bug.
+      let chk =
+        negate:
+          negate:
+            negate:
+              isEmpty:
+                makeStr "foo"
+      check chk
 
     trampoline foo()
     check r == 1


### PR DESCRIPTION
The previous algorithm has an error:

    Prefix            <- Rewritten
      Sym "not"
      Infix           <- Rewritten
        Sym "=="
        StmtListExpr  <- Not rewritten
          Ident "foo"
        Ident "bar"

Where StmtListExpr is a direct descendant of a call node (Infix) but was
not rewritten.