### PR TITLE
cps, cps/environment: only desym environment fields

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -47,7 +47,11 @@ proc isCpsCall(n: NimNode): bool =
   assert not n.isNil
   if len(n) > 0:
     if n.kind in callish:
-      let p = n.getCallSym.getImpl
+      let p =
+        try:
+          n.getCallSym.getImpl
+        except:
+          newEmptyNode()
       result = p.hasPragma("cpsCall")
 
 proc firstReturn(p: NimNode): NimNode =
@@ -808,9 +812,9 @@ proc cpsXfrmProc(T: NimNode, n: NimNode): NimNode =
   env = env.storeType(force = off)
 
   # Araq: "learn how to desemantic your ast, knuckleheads"
-  n.body = replacedSymsWithIdents(n.body)
-  types = replacedSymsWithIdents(types)
-  booty = replacedSymsWithIdents(booty)
+  #n.body = replacedSymsWithIdents(n.body)
+  #types = replacedSymsWithIdents(types)
+  #booty = replacedSymsWithIdents(booty)
 
   # lifting the generated proc bodies
   result = lambdaLift(types, n)

--- a/cps.nim
+++ b/cps.nim
@@ -812,9 +812,11 @@ proc cpsXfrmProc(T: NimNode, n: NimNode): NimNode =
   env = env.storeType(force = off)
 
   # Araq: "learn how to desemantic your ast, knuckleheads"
-  #n.body = replacedSymsWithIdents(n.body)
-  #types = replacedSymsWithIdents(types)
-  #booty = replacedSymsWithIdents(booty)
+  # No longer necessary as we are desym-ing on a selective basis
+  when false:
+    n.body = replacedSymsWithIdents(n.body)
+    types = replacedSymsWithIdents(types)
+    booty = replacedSymsWithIdents(booty)
 
   # lifting the generated proc bodies
   result = lambdaLift(types, n)

--- a/cps.nim
+++ b/cps.nim
@@ -39,9 +39,8 @@ func getCallSym(n: NimNode): NimNode =
       break
     of nnkIdent:
       result = nil
-      break
     else:
-      assert false, "unknown node type: " & $result.kind
+      raise newException(Defect, "unknown node type: " & $result.kind)
 
 proc isCpsCall(n: NimNode): bool =
   ## true if this node holds a call to a cps procedure

--- a/cps.nim
+++ b/cps.nim
@@ -28,6 +28,7 @@ when defined(yourdaywillcomelittleonecommayourdaywillcomedotdotdot):
 
 func getCallSym(n: NimNode): NimNode =
   ## Get the symbol that is being called
+  ## Returns nil if there is no symbol
   expectKind n, callish
   result = n[0]
   while result != nil:
@@ -37,22 +38,19 @@ func getCallSym(n: NimNode): NimNode =
     of nnkSym:
       break
     of nnkIdent:
-      raise newException(CatchableError, "This call is not typed")
+      result = nil
+      break
     else:
       assert false, "unknown node type: " & $result.kind
-  assert not result.isNil
 
 proc isCpsCall(n: NimNode): bool =
   ## true if this node holds a call to a cps procedure
   assert not n.isNil
   if len(n) > 0:
     if n.kind in callish:
-      let p =
-        try:
-          n.getCallSym.getImpl
-        except:
-          newEmptyNode()
-      result = p.hasPragma("cpsCall")
+      let callee = n.getCallSym
+      if not callee.isNil:
+        result = callee.getImpl.hasPragma("cpsCall")
 
 proc firstReturn(p: NimNode): NimNode =
   ## find the first return statement within statement lists, or nil

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -191,7 +191,7 @@ proc castToChild(e: Env; n: NimNode): NimNode =
   when cpsCast:
     result = newTree(nnkCast, e.identity, n)
   else:
-    result = newTree(nnkCall, desym e.identity, n)
+    result = newTree(nnkCall, e.identity, n)
 
 proc maybeConvertToRoot*(e: Env; locals: NimNode): NimNode =
   ## add an Obj(foo: bar).Other conversion if necessary
@@ -285,7 +285,7 @@ proc makeType*(e: var Env): NimNode =
   # determine if a symbol clash necessitates pointing to a new parent
   #performReparent(e)
 
-  result = nnkTypeDef.newTree(desym e.id, newEmptyNode(), e.objectType)
+  result = nnkTypeDef.newTree(e.id, newEmptyNode(), e.objectType)
 
 proc first*(e: Env): NimNode = e.c
 proc firstDef*(e: Env): NimNode =
@@ -513,7 +513,7 @@ iterator localSection*(e: var Env; n: NimNode): Pair =
 proc newContinuation*(e: Env; via: NimNode;
                       goto: NimNode; defaults = false): NimNode =
   ## else, perform the following alloc...
-  result = nnkObjConstr.newTree(desym e.identity, newColonExpr(e.fn, goto))
+  result = nnkObjConstr.newTree(e.identity, newColonExpr(e.fn, goto))
   for field, section in pairs(e):
     # omit special fields in the env that we use for holding
     # custom functions, results, and exceptions, respectively

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -277,7 +277,7 @@ proc errorAst*(n: NimNode; s = "creepy ast"): NimNode =
   errorAst s & ":\n" & treeRepr(n) & "\n"
 
 proc genField*(ident = ""): NimNode =
-  ## generate an unique field to put inside an object definition
+  ## generate a unique field to put inside an object definition
   ##
-  ## made as a walkaround for [nim-lang/Nim#17851](https://github.com/nim-lang/Nim/issues/17851)
+  ## made as a workaround for [nim-lang/Nim#17851](https://github.com/nim-lang/Nim/issues/17851)
   desym genSym(nskField, ident)

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -275,3 +275,9 @@ proc errorAst*(s: string): NimNode =
 proc errorAst*(n: NimNode; s = "creepy ast"): NimNode =
   ## embed an error with a message
   errorAst s & ":\n" & treeRepr(n) & "\n"
+
+proc genField*(ident = ""): NimNode =
+  ## generate an unique field to put inside an object definition
+  ##
+  ## made as a walkaround for [nim-lang/Nim#17851](https://github.com/nim-lang/Nim/issues/17851)
+  desym genSym(nskField, ident)

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -588,35 +588,29 @@ testes:
 
   block:
     ## call a macro that calls a foreign symbol
-    when true:
-      skip "not working yet, see #53"
-    else:
-      r = 0
-      proc foo() {.cps: Cont.} =
-        inc r
-        let i = 42
-        noop()
-        inc r
-        check jsonifyImplicit(i) == $i
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      let i = 42
+      noop()
+      inc r
+      check jsonifyImplicit(i) == $i
 
-      trampoline foo()
-      check r == 2
+    trampoline foo()
+    check r == 2
 
   block:
     ## call a template with explicit bind
-    when true:
-      skip "not working yet, see #53"
-    else:
-      r = 0
-      proc foo() {.cps: Cont.} =
-        inc r
-        let i = 42
-        noop()
-        inc r
-        check jsonifyBind(i) == $i
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      let i = 42
+      noop()
+      inc r
+      check jsonifyBind(i) == $i
 
-      trampoline foo()
-      check r == 2
+    trampoline foo()
+    check r == 2
 
   block:
     ## template call in nested call nodes


### PR DESCRIPTION
Experiments shows that we only have to desym due to issues in
environment definition and access.

Upstream bug: nim-lang/Nim#17851

Has #72 bundled.

By keeping the symbols, we avoid the foreign bindsym issue altogether.