### PR TITLE
cps: remove getCallSym

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -26,29 +26,14 @@ when defined(yourdaywillcomelittleonecommayourdaywillcomedotdotdot):
   const
     cpsish = {nnkYieldStmt, nnkContinueStmt}  ## precede cps calls
 
-func getCallSym(n: NimNode): NimNode =
-  ## Get the symbol that is being called
-  ## Returns nil if there is no symbol
-  expectKind n, callish
-  result = n[0]
-  while result != nil:
-    case result.kind
-    of nnkDotExpr:
-      result = result[1]
-    of nnkSym:
-      break
-    of nnkIdent:
-      result = nil
-    else:
-      raise newException(Defect, "unknown node type: " & $result.kind)
-
 proc isCpsCall(n: NimNode): bool =
   ## true if this node holds a call to a cps procedure
   assert not n.isNil
   if len(n) > 0:
     if n.kind in callish:
-      let callee = n.getCallSym
-      if not callee.isNil:
+      let callee = n[0]
+      # all cpsCall are normal functions called via a generated symbol
+      if not callee.isNil and callee.kind == nnkSym:
         result = callee.getImpl.hasPragma("cpsCall")
 
 proc firstReturn(p: NimNode): NimNode =

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -641,3 +641,18 @@ testes:
 
     trampoline foo()
     check r == 1
+
+  block:
+    ## calling a function pointer produced by an expression
+    proc bar(i: int): proc(): int =
+      result = proc(): int =
+        i * 2
+
+    proc foo() {.cps: Cont.} =
+      var i = 2
+      noop()
+      i = bar(i)()
+      noop()
+      check i == 4
+
+    trampoline foo()


### PR DESCRIPTION
getCallSym() was written on the assumption that all callees are
symbols, which is not the case.

Added the test case that prompted this change.

Fixes #74