### PR TITLE
cps: rewrite defer to try-finally

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -886,7 +886,7 @@ proc cpsXfrmProc(T: NimNode, n: NimNode): NimNode =
   n.body = env.prepProcBody(newStmtList n.body)
 
   # transform defers
-  n.body = xfrmDefer n.body
+  n.body = rewriteDefer n.body
 
   # ensaftening the proc's body
   n.body = env.saften(n.body)

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -580,13 +580,12 @@ proc rewriteDefer*(n: NimNode): NimNode =
 
       # Look for the defer in the child nodes
       for idx, child in n:
-        let collected = splitDefer(child)
-        result.defer = collected.defer
-        if not collected.before.isNil:
-          result.before.add collected.before
+        if child.hasDefer:
+          let collected = splitDefer(child)
+          result.defer = collected.defer
+          if not collected.before.isNil:
+            result.before.add collected.before
 
-        # If the defer node is found
-        if not result.defer.isNil:
           # Add nodes coming after the defer to the list of affected nodes
           if not collected.affected.isNil:
             result.affected.add collected.affected
@@ -594,6 +593,9 @@ proc rewriteDefer*(n: NimNode): NimNode =
             result.affected.add n[idx + 1 .. ^1]
           # We are done here
           break
+
+        # If there are no defer in the child node, add as-is
+        result.before.add child
     else:
       # This node doesn't contain any defer, return as-is
       result.before = n

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -539,3 +539,15 @@ func breakLabel*(n: NimNode): NimNode =
     n[0]
   else:
     raise newException(Defect, "this node is not a break: " & $n.kind)
+
+func flattenStmtList*(n: NimNode): NimNode =
+  ## Flatten all StmtList nested in `n`
+  doAssert n.kind in {nnkStmtList, nnkStmtListExpr}
+  result = copyNimNode n
+
+  for child in n:
+    if child.kind in {nnkStmtList, nnkStmtListExpr}:
+      for grandchild in flattenStmtList(child):
+        result.add grandchild
+    else:
+      result.add child

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -858,3 +858,39 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 4
+
+  block:
+    ## basic defer rewrite
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      defer:
+        check r == 4
+        inc r
+      inc r
+      defer:
+        check r == 3
+        inc r
+      inc r
+
+    trampoline foo()
+    check r == 5
+
+  block:
+    ## defer in nested stmtlist rewrite
+    r = 0
+
+    template deferChk(i: int) =
+      inc r
+      defer:
+        check r == i
+        inc r
+
+    proc foo() {.cps: Cont.} =
+      deferChk(5)
+      inc r
+      deferChk(4)
+      inc r
+
+    trampoline foo()
+    check r == 6

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -894,3 +894,21 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 6
+
+  block:
+    ## defer in block rewrite
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      block:
+        defer:
+          check r == 2
+          inc r
+        inc r
+      defer:
+        check r == 4
+        inc r
+      inc r
+
+    trampoline foo()
+    check r == 5

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -912,3 +912,23 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 5
+
+  block:
+    ## there is only defer rewrite
+    r = 0
+    proc foo() {.cps: Cont.} =
+      defer:
+        inc r
+
+    trampoline foo()
+    check r == 1
+
+  block:
+    ## there is only defer rewrite
+    r = 0
+    proc foo() {.cps: Cont.} =
+      defer:
+        inc r
+
+    trampoline foo()
+    check r == 1

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -922,13 +922,3 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 1
-
-  block:
-    ## there is only defer rewrite
-    r = 0
-    proc foo() {.cps: Cont.} =
-      defer:
-        inc r
-
-    trampoline foo()
-    check r == 1


### PR DESCRIPTION
The properties described in
https://nim-lang.org/docs/manual.html#exception-handling-defer-statement
appears to be preserved correctly.

~~This breaks `tzevv`'s "defer" test, since we don't handle try-finally.~~ No longer happening with the new approach.