### PR TITLE
cps: make cpsMagic proc raises Defect when used outside {.cps.}

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -959,11 +959,19 @@ macro cpsMagic*(n: untyped): untyped =
   when false:
     m.addPragma newColonExpr(ident"error", msg.newLit)
     m.body.add nnkDiscardStmt.newNimNode(n).add newEmptyNode()
-  elif defined(release) and not defined(cpsDebug):
+  elif false and defined(release) and not defined(cpsDebug):
     m.body.add nnkPragma.newNimNode(n).add newColonExpr(ident"warning",
                                                         msg.newLit)
   elif false:
     m.body.add nnkCall.newNimNode(n).newTree(ident"error", msg.newLit)
+  else:
+    m.body.add:
+      nnkRaiseStmt.newTree:
+        newCall(
+          bindSym"newException",
+          nnkBracketExpr.newTree(bindSym"typedesc", bindSym"Defect"),
+          newLit(msg)
+        )
   # add it to our statement list result
   result.add m
 


### PR DESCRIPTION
Currently we put a `{.warning.}` inside the proc which does... absolutely
nothing but generates an useless warning.

Options to catch this at compile-time are non-existant, unfortunately,
since the procs using these cpsMagic procedures must sem before
they can be processed by `{.cps.}`.

So instead we are gonna make these cpsMagic proc raises when the
"non-cps" version is used outside of `{.cps.}`. Should help us catches
bugs in the transform if we misses anything.