### PR TITLE
cps/spec: rework varargs rewrite

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -399,27 +399,36 @@ proc normalizingRewrites*(n: NimNode): NimNode =
           result.add:
             normalizingRewrites child
       of CallNodes - {nnkHiddenCallConv}:
-        if n.len > 1 and n.last.kind == nnkHiddenStdConv:
+        if n.len > 1 and not n.findChild(it.kind == nnkHiddenStdConv).isNil:
           result = copyNimNode n
-          for index in 0 ..< n.len - 1: # ie, omit last
-            result.add:
-              normalizingRewrites n[index]
-          # now deal with the hidden conversions
-          var c = n.last
-          # rewrite varargs conversions; perhaps can be replaced by
-          # nnkArgsList if it acquires some special cps call handling
-          if c.last.kind == nnkBracket:
-            for converted in c.last.items:
+          for index, child in n.pairs:
+            if child.kind != nnkHiddenStdConv:
               result.add:
-                normalizingRewrites converted
-          # these are implicit conversions the compiler can handle
-          elif c.len > 1 and c[0].kind == nnkEmpty:
-            for converted in c[1 .. ^1]:
-              result.add:
-                normalizingRewrites converted
-          else:
-            raise newException(Defect,
-              "unexpected conversion form:\n" & treeRepr(c))
+                normalizingRewrites child
+            else:
+              # rewrite varargs conversions; perhaps can be replaced by
+              # nnkArgsList if it acquires some special cps call handling
+              if child.last.kind == nnkBracket:
+                if n.kind in {nnkPrefix, nnkInfix, nnkPostfix} or
+                   index < n.len - 1:
+                  # if this varargs is not the last argument
+                  # or if the call node is a binary/unary node, which
+                  # then they can't have more than one/two parameters,
+                  # thus the varargs must be in nnkBracket
+                  result.add:
+                    normalizingRewrites child.last
+                else:
+                  for converted in child.last.items:
+                    result.add:
+                      normalizingRewrites converted
+              # these are implicit conversions the compiler can handle
+              elif child.len > 1 and child[0].kind == nnkEmpty:
+                for converted in child[1 .. ^1]:
+                  result.add:
+                    normalizingRewrites converted
+              else:
+                raise newException(Defect,
+                  "unexpected conversion form:\n" & treeRepr(child))
       else:
         discard
 

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -922,3 +922,61 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 1
+
+  block:
+    ## varargs rewrites
+    # various forms of concat
+    func concatConv(parts: varargs[string, `$`]): string =
+      for i in parts:
+        result.add i
+
+    func concat(parts: varargs[string]): string =
+      for i in parts:
+        result.add i
+
+    func concatDuo(a, b: varargs[string]): string =
+      for i in a:
+        result.add i
+      for i in b:
+        result.add i
+
+    func `&!`(parts: varargs[string]): string =
+      for i in parts:
+        result.add i
+
+    func `&`(s: string, parts: varargs[string]): string =
+      result = s
+      for i in parts:
+        result.add i
+
+    func `%&`(parts: varargs[string], s: string): string =
+      for i in parts:
+        result.add i
+      result.add s
+
+    func `%&%`(a, b: varargs[string]): string =
+      for i in a:
+        result.add i
+      for i in b:
+        result.add i
+
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      check concatConv("foo ", 42, 0) == "foo 420"
+      check concat("foo ", $42, $0) == "foo 420"
+      check concatDuo(["f", "o", "o "], $42, $0) == "foo 420"
+      check &!["foo ", $42, $0] == "foo 420"
+      check "foo " & [$42, $0] == "foo 420"
+      check ["f", "o", "o "] %& "420" == "foo 420"
+      check ["foo "] %&% [$42, $0] == "foo 420"
+      check concatConv(@["foo ", $42, $0]) == "foo 420"
+      check concat(@["foo ", $42, $0]) == "foo 420"
+      check concatDuo(@["f", "o", "o "], @[$42, $0]) == "foo 420"
+      check &!(@["foo ", $42, $0]) == "foo 420"
+      check "foo " & @[$42, $0] == "foo 420"
+      check @["f", "o", "o "] %& "420" == "foo 420"
+      check @["foo "] %&% @[$42, $0] == "foo 420"
+
+    trampoline foo()
+    check r == 1


### PR DESCRIPTION
Mostly moving code around, but the difference is that brackets
are now kept when the node being rewritten is not the last node
or when the call node is a binary/unary call.

Fixes the issue @disruptek sent on IRC and a bunch more.