### PR TITLE
fix for loop without split transform

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -296,7 +296,7 @@ else:
 proc errorAst*(s: string, info: NimNode = nil): NimNode =
   ## produce {.error: s.} in order to embed errors in the ast
   ##
-  ## optionally take a node to set the error line information to
+  ## optionally take a node to set the error line information
   result = nnkPragma.newTree:
     ident"error".newColonExpr: newLit s
   if not info.isNil:
@@ -305,6 +305,8 @@ proc errorAst*(s: string, info: NimNode = nil): NimNode =
 proc errorAst*(n: NimNode; s = "creepy ast"): NimNode =
   ## embed an error with a message, the line info is copied from the node
   ## too
+  # TODO: we might no longer need this now that the other version can
+  #       get the line info
   errorAst(s & ":\n" & treeRepr(n) & "\n", n)
 
 proc genField*(ident = ""): NimNode =

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -293,14 +293,19 @@ when cpsDebug:
 else:
   template lineAndFile*(n: NimNode): string = "(no debug)"
 
-proc errorAst*(s: string): NimNode =
+proc errorAst*(s: string, info: NimNode = nil): NimNode =
   ## produce {.error: s.} in order to embed errors in the ast
-  nnkPragma.newTree:
+  ##
+  ## optionally take a node to set the error line information to
+  result = nnkPragma.newTree:
     ident"error".newColonExpr: newLit s
+  if not info.isNil:
+    result[0].copyLineInfo info
 
 proc errorAst*(n: NimNode; s = "creepy ast"): NimNode =
-  ## embed an error with a message
-  errorAst s & ":\n" & treeRepr(n) & "\n"
+  ## embed an error with a message, the line info is copied from the node
+  ## too
+  errorAst(s & ":\n" & treeRepr(n) & "\n", n)
 
 proc genField*(ident = ""): NimNode =
   ## generate a unique field to put inside an object definition

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -998,17 +998,19 @@ suite "tasteful tests":
 
   block:
     ## for loops with continue, break and a split
-    skip"pending #48"
-    r = 0
-    proc foo() {.cps: Cont.} =
-      inc r
-      for i in 0 .. 3:
-        noop()
-        if i == 0:
-          continue
-        if i > 2:
-          break
-        r.inc i
+    when true:
+      skip"pending #48"
+    else:
+      r = 0
+      proc foo() {.cps: Cont.} =
+        inc r
+        for i in 0 .. 3:
+          noop()
+          if i == 0:
+            continue
+          if i > 2:
+            break
+          r.inc i
 
-    trampoline foo()
-    check r == 4
+      trampoline foo()
+      check r == 4

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -980,3 +980,35 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 1
+
+  block:
+    ## for loops with continue, break
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      for i in 0 .. 3:
+        if i == 0:
+          continue
+        if i > 2:
+          break
+        r.inc i
+
+    trampoline foo()
+    check r == 4
+
+  block:
+    ## for loops with continue, break and a split
+    skip"pending #48"
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      for i in 0 .. 3:
+        noop()
+        if i == 0:
+          continue
+        if i > 2:
+          break
+        r.inc i
+
+    trampoline foo()
+    check r == 4


### PR DESCRIPTION
Fix the bug where a for loop will have `{.cpsBreak.}` and `{.cpsContinue.}`
in its body even when it's not a cpsBlock.

Additionally we signal an error when the loop is a cpsBlock since we haven't
got a rewrite for that yet.