### PR TITLE
cps/spec: document hasLiftableChild

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -283,6 +283,7 @@ proc isLiftable*(n: NimNode): bool =
   result = n.kind in {nnkProcDef, nnkTypeSection} and n.hasPragma "cpsLift"
 
 proc hasLiftableChild*(n: NimNode): bool =
+  ## does this node contain liftable nodes?
   result = anyIt(toSeq items(n), it.isLiftable or it.hasLiftableChild)
 
 when cpsDebug:


### PR DESCRIPTION
This serves as a walkaround for nim-lang/Nim#17835

Should make CPS green