### PR TITLE
several issues with tuple deconstruction

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -366,7 +366,7 @@ macro cpsJump(cont, call, n: typed): untyped =
   expectKind cont, nnkSym
   expectKind call, nnkCallKinds
 
-  debug("cpsJump", n, Original)
+  #debug("cpsJump", n, Original)
 
   result = newStmtList()
 
@@ -381,7 +381,7 @@ macro cpsJump(cont, call, n: typed): untyped =
 
   result = workaroundRewrites(result)
 
-  debug("cpsJump", result, Transformed, n)
+  #debug("cpsJump", result, Transformed, n)
 
 macro cpsJump(cont, call: typed): untyped =
   ## a version of cpsJump that doesn't take a continuing body.
@@ -394,8 +394,8 @@ macro cpsMayJump(cont, n, after: typed): untyped =
   ## to `after`.
   expectKind cont, nnkSym
 
-  debug("cpsMayJump", n, Original)
-  debug("cpsMayJump", after, Original)
+  #debug("cpsMayJump", n, Original)
+  #debug("cpsMayJump", after, Original)
 
   # we always wrap the input because there's no reason not to
   var n = newStmtList n
@@ -420,7 +420,7 @@ macro cpsMayJump(cont, n, after: typed): untyped =
 
   result = workaroundRewrites result
 
-  debug("cpsMayJump", result, Transformed, n)
+  #debug("cpsMayJump", result, Transformed, n)
 
 func matchCpsBreak(label: NimNode): Matcher =
   ## create a matcher matching cpsBreak with the given label
@@ -465,7 +465,7 @@ macro cpsBlock(cont, label, n: typed): untyped =
   expectKind cont, nnkSym
   expectKind label, {nnkSym, nnkEmpty}
 
-  debug("cpsBlock", n, Original)
+  #debug("cpsBlock", n, Original)
 
   # we always wrap the input because there's no reason not to
   var n = newStmtList n
@@ -477,7 +477,7 @@ macro cpsBlock(cont, label, n: typed): untyped =
 
   result = workaroundRewrites result
 
-  debug("cpsBlock", result, Transformed, n)
+  #debug("cpsBlock", result, Transformed, n)
 
 macro cpsBlock(cont, n: typed): untyped =
   ## a block statement tained by a `cpsJump` and may require a jump to enter `after`.
@@ -494,7 +494,7 @@ macro cpsWhile(cont, cond, n: typed): untyped =
   ## control-flow.
   expectKind cont, nnkSym
 
-  debug("cpsWhile", newTree(nnkWhileStmt, cond, n), Original, cond)
+  #debug("cpsWhile", newTree(nnkWhileStmt, cond, n), Original, cond)
 
   result = newStmtList()
 
@@ -518,7 +518,7 @@ macro cpsWhile(cont, cond, n: typed): untyped =
 
   result = workaroundRewrites result
 
-  debug("cpsWhile", result, Transformed, cond)
+  #debug("cpsWhile", result, Transformed, cond)
 
 proc saften(parent: var Env; n: NimNode): NimNode =
   ## transform `input` into a mutually-recursive cps convertible form
@@ -755,7 +755,7 @@ macro cpsResolver(T: typed, n: typed): untyped =
   ## this is not needed, but it's here so we can change this to
   ## a sanity check pass later.
   expectKind n, nnkProcDef
-  debug(".cpsResolver.", n, Original)
+  #debug(".cpsResolver.", n, Original)
 
   # make `n` safe for modification
   let n = normalizingRewrites n
@@ -764,7 +764,7 @@ macro cpsResolver(T: typed, n: typed): untyped =
   result = danglingCheck(result)
   result = workaroundRewrites(result)
 
-  debug(".cpsResolver.", result, Transformed, n)
+  #debug(".cpsResolver.", result, Transformed, n)
 
 proc xfrmFloat(n: NimNode): NimNode =
   var floats = newStmtList()
@@ -783,12 +783,12 @@ proc xfrmFloat(n: NimNode): NimNode =
 macro cpsFloater(n: typed): untyped =
   ## float all `{.cpsLift.}` to top-level
   expectKind n, nnkProcDef
-  debug(".cpsFloater.", n, Original)
+  #debug(".cpsFloater.", n, Original)
 
   var n = copyNimTree n
   result = xfrmFloat n
 
-  debug(".cpsFloater.", result, Transformed, n)
+  #debug(".cpsFloater.", result, Transformed, n)
 
 proc cpsXfrmProc(T: NimNode, n: NimNode): NimNode =
   ## rewrite the target procedure in Continuation-Passing Style

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -442,6 +442,15 @@ iterator addAssignment(e: var Env; kind: NimNodeKind; defs: NimNode): NimNode =
       echo $kind, "\t", repr(defs)
     yield e.initialization(kind, field, value)
 
+proc getFieldViaLocal(e: Env; n: NimNode): NimNode =
+  ## get a field from the env using a local symbol as input
+  for field, sym in e.locals.pairs:
+    if sym == n:
+      result = field
+      break
+  if result.isNil:
+    result = n.errorAst "unable to find field for symbol " & n.repr
+
 proc findJustOneAssignmentName*(e: Env; n: NimNode): NimNode =
   case n.kind
   of nnkVarSection, nnkLetSection:
@@ -455,7 +464,7 @@ proc findJustOneAssignmentName*(e: Env; n: NimNode): NimNode =
     elif n.len != 3:
       n.errorAst "only one identifier per assignment is supported"
     else:
-      e.locals[n[0]]
+      e.getFieldViaLocal n
   of nnkVarTuple:
     n.errorAst "tuples not supported yet"
   else:

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -324,13 +324,22 @@ proc normalizingRewrites*(n: NimNode): NimNode =
         for child in n.items:
           case child.kind
           of nnkVarTuple:
-            # a new section with a single rewritten identdefs within
-            # for each symbol in the VarTuple statement
-            for i, value in child.last.pairs:
+            # we used to rewrite these, but the rewrite is only safe for
+            # very trivial deconstructions.  now we rewrite the symbols
+            # into the env during the saften pass as necessary.
+            when false:
+              # a new section with a single rewritten identdefs within
+              # for each symbol in the VarTuple statement
+              for i, value in child.last.pairs:
+                result.add:
+                  newNimNode(n.kind, n).add:
+                    rewriteIdentDefs:  # for consistency
+                      newIdentDefs(child[i], getTypeInst value, value)
+            else:
+              # a new section with a single VarTuple statement
               result.add:
                 newNimNode(n.kind, n).add:
-                  rewriteIdentDefs:  # for consistency
-                    newIdentDefs(child[i], getType(value), value)
+                  child
           of nnkIdentDefs:
             # a new section with a single rewritten identdefs within
             result.add:

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -99,6 +99,8 @@ suite "tasteful tests":
     type
       Goats = distinct int
       Pigs = distinct float
+    proc `==`(a, b: Goats): bool {.borrow.}
+    proc `==`(a, b: Pigs): bool {.borrow.}
     r = 0
     proc foo() {.cps: Cont.} =
       inc r
@@ -107,8 +109,8 @@ suite "tasteful tests":
       inc r
       noop()
       check "declared variables":
-        i == 4
-        k == 7.0
+        i == 4.Goats
+        k == Pigs 7.0
     trampoline foo()
     check r == 2
 

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -78,6 +78,41 @@ suite "tasteful tests":
     check j == 5
 
   block:
+    ## deconstruction with a call source
+    r = 0
+    proc bar(): (int, float) = (4, 7.0)
+
+    proc foo() {.cps: Cont.} =
+      inc r
+      let (i, k) = bar()
+      noop()
+      inc r
+      noop()
+      check "declared variables":
+        i == 4
+        k == 7.0
+    trampoline foo()
+    check r == 2
+
+  block:
+    ## deconstruction with distinct types
+    type
+      Goats = distinct int
+      Pigs = distinct float
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      let (i, k) = (Goats 4, Pigs 7.0)
+      noop()
+      inc r
+      noop()
+      check "declared variables":
+        i == 4
+        k == 7.0
+    trampoline foo()
+    check r == 2
+
+  block:
     ## declaration via tuple deconstruction
     r = 0
     proc foo() {.cps: Cont.} =


### PR DESCRIPTION
This solves a couple problems with tuples that mostly manifest like this:

```nim
let (a, b, c) = foo()
```
is now
```nim
(env.a, env.b, env.c) = foo()
```
...and there was something wacky with distinct types in tuple deconstruction that was more trivial.

Also, it simplifies `localSection` to no longer iterate, `addAssignment` to yield only one value, and removes some other dead code in `initialization`.

Also comments out all but the "top-level" debugging output.

Also adds a procedure for fetching a single LHS symbol for assignment in the shim codepath, which I don't think we actually use.  It made more sense to do this than complicate the other aforementioned procs...