### PR TITLE
cps: always wrap the while body in an stmtlist

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -692,9 +692,12 @@ proc saften(parent: var Env; n: NimNode): NimNode =
         let jumpCall = newCall(bindSym"cpsWhile")
         jumpCall.copyLineInfo nc
         jumpCall.add env.first
-        for child in nc:
-          jumpCall.add:
-            env.saften child
+        # add condition
+        jumpCall.add:
+          env.saften nc[0]
+        # add body
+        jumpCall.add:
+          env.saften newStmtList(nc[1])
         result.add jumpCall
         return
       else:

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1051,3 +1051,21 @@ suite "tasteful tests":
 
       trampoline foo()
       check r == 4
+
+  block:
+    ## while loop with only one cpsCall
+    proc jield(c: Cont): Cont {.cpsMagic.} =
+      discard
+
+    r = 0
+    proc count() {.cps: Cont.} =
+      inc r
+      var i = 0
+
+      while i < 2:
+        jield()
+
+      fail "this statement should not run"
+
+    trampoline count()
+    check r == 1


### PR DESCRIPTION
The compiler tends to flatten an StmtList with one child, thus when
the body of `while` only have one statement that is a cps call,
saften operates on the children of the call instead of the call
itself.

We fix this by always wrapping the body of a while loop in an
StmtList.

Fixes #106 