### PR TITLE
cooperative yield

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -64,3 +64,8 @@ template finished*(c: Continuation): bool =
 template dismissed*(c: Continuation): bool =
   ## `true` if the continuation was dimissed.
   c.state == Dismissed
+
+template coop*(c: Continuation): Continuation {.used.} =
+  ## This symbol may be reimplemented as a `.cpsMagic.` to introduce
+  ## a cooperative yield at appropriate continuation exit points.
+  c


### PR DESCRIPTION
It seems to work, but we'll need @zevv to see how it performs in his pool.  We assume that if we're calling a procedure (and not merely returning the continuation) that the target procedure is in position to either call a `coop` itself or perform similar logic, so in that case, we don't use `coop`.  But for "normal" control-flow, it gets access to the continuation after the next leg is installed but before it is executed.

There are a couple things that need review:

- `isCpsBlock` and `isCpsCall` and standardizing on `nnkCallNodes`