### PR TITLE
formalized hooks: trace, alloc, dealloc, coop

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ to [the documentation](https://disruptek.github.io/eventqueue/eventqueue.html).
 ## Hacking
 
 - use `--define:cpsDebug` to get extra debugging output
-- use `--define:cpsTrace` to get continuation tracing from the trampoline
 - use `--define:cpsTree` to dump AST via `treeRepr` in `cpsDebug` mode
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ The continuations produced by this macro...
 - compose efficient and idiomatic asynchronous code
 - are over a thousand times lighter than threads
 - are leak-free under Nim's ARC/ORC memory management
-- may be based upon your own custom `ref object`
+- may be based upon your own custom `ref object` type
 - may be dispatched using your own custom dispatcher
 - may be moved between threads to parallelize execution
 - are faster and lighter than async/await futures
-- have nearly zero overhead versus closure iterators
+- are 5-15% faster than native closure iterators
 - exploit no unsafe features of the language (`cast`, `ptr`, `addr`, `emit`)
 
 ## This is Work In Progress!

--- a/cps.nim
+++ b/cps.nim
@@ -74,3 +74,13 @@ template trace*(c: Continuation; fun: string; where: LineInfo) {.used.} =
   ## This symbol may be reimplemented to introduce control-flow
   ## tracing of the entry to each continuation leg.
   discard
+
+template alloc*[T: Continuation](c: typedesc[T]): T {.used.} =
+  ## This symbol may be reimplemented to customize continuation
+  ## allocation.
+  new c
+
+template dealloc*(c: sink Continuation) {.used.} =
+  ## This symbol may be reimplemented to customize continuation
+  ## deallocation.
+  discard

--- a/cps.nim
+++ b/cps.nim
@@ -70,7 +70,7 @@ template coop*(c: Continuation): Continuation {.used.} =
   ## a cooperative yield at appropriate continuation exit points.
   c
 
-template trace*(fun: string; where: LineInfo) {.used.} =
+template trace*(c: Continuation; fun: string; where: LineInfo) {.used.} =
   ## This symbol may be reimplemented to introduce control-flow
   ## tracing of the entry to each continuation leg.
   discard

--- a/cps.nim
+++ b/cps.nim
@@ -1,7 +1,7 @@
 import std/[macros]
 import cps/[spec, xfrm]
 export Continuation, ContinuationProc, cpsCall
-export cpsDebug, cpsTrace
+export cpsDebug
 
 type
   State* {.pure.} = enum

--- a/cps.nim
+++ b/cps.nim
@@ -84,7 +84,8 @@ template alloc*[T: Continuation](c: typedesc[T]): T {.used.} =
   ## allocation.
   new c
 
-template dealloc*(c: sink Continuation) {.used.} =
+template dealloc*[T: Continuation](t: typedesc[T];
+                                   c: sink Continuation) {.used.} =
   ## This symbol may be reimplemented to customize continuation
   ## deallocation.
   discard

--- a/cps.nim
+++ b/cps.nim
@@ -69,3 +69,8 @@ template coop*(c: Continuation): Continuation {.used.} =
   ## This symbol may be reimplemented as a `.cpsMagic.` to introduce
   ## a cooperative yield at appropriate continuation exit points.
   c
+
+template trace*(fun: string; where: LineInfo) {.used.} =
+  ## This symbol may be reimplemented to introduce control-flow
+  ## tracing of the entry to each continuation leg.
+  discard

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -254,6 +254,15 @@ proc newEnv*(c: NimNode; store: var NimNode; via: NimNode): Env =
   assert not via.isNil
   assert not via.isEmpty
   var c = if c.isNil or c.isEmpty: ident"continuation" else: c
+
+  # add a check to make sure the supplied type will work for descendants
+  let check = nnkWhenStmt.newNimNode via
+  check.add:
+    nnkElifBranch.newTree:
+      [ infix(via, "isnot", ident"Continuation"),
+        errorAst repr(via) & " does not match the Continuation concept" ]
+  store.add check
+
   result = Env(c: c, store: store, via: via, id: via)
   result.seen = initHashSet[string]()
   init result

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -326,25 +326,26 @@ proc getFieldViaLocal(e: Env; n: NimNode): NimNode =
   if result.isNil:
     result = n.errorAst "unable to find field for symbol " & n.repr
 
-proc findJustOneAssignmentName*(e: Env; n: NimNode): NimNode
-  {.deprecated: "not used yet".} =
-  case n.kind
-  of nnkVarSection, nnkLetSection:
-    if n.len != 1:
-      n.errorAst "only one assignment per section is supported"
+when false:
+  proc findJustOneAssignmentName*(e: Env; n: NimNode): NimNode
+    {.deprecated: "not used yet".} =
+    case n.kind
+    of nnkVarSection, nnkLetSection:
+      if n.len != 1:
+        n.errorAst "only one assignment per section is supported"
+      else:
+        e.findJustOneAssignmentName n[0]
+    of nnkIdentDefs:
+      if n.len != 3:
+        n.errorAst "only one identifier per assignment is supported"
+      elif n[0].kind notin {nnkIdent, nnkSym}:
+        n.errorAst "bad rewrite presented bogus input"
+      else:
+        e.getFieldViaLocal n
+    of nnkVarTuple:
+      n.errorAst "tuples not supported yet"
     else:
-      e.findJustOneAssignmentName n[0]
-  of nnkIdentDefs:
-    if n.len != 3:
-      n.errorAst "only one identifier per assignment is supported"
-    elif n[0].kind notin {nnkIdent, nnkSym}:
-      n.errorAst "bad rewrite presented bogus input"
-    else:
-      e.getFieldViaLocal n
-  of nnkVarTuple:
-    n.errorAst "tuples not supported yet"
-  else:
-    n.errorAst "unrecognized input"
+      n.errorAst "unrecognized input"
 
 proc localSection*(e: var Env; n: NimNode; into: NimNode = nil) =
   ## consume a var|let section and yield name, node pairs

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -432,9 +432,3 @@ proc rewriteSymbolsIntoEnvDotField*(e: var Env; n: NimNode): NimNode =
   let child = e.castToChild(e.first)
   for field, section in pairs(e):
     result = result.resym(section[0][0], newDotExpr(child, field))
-
-proc defineProc*(e: var Env; p: NimNode) =
-  ## add a proc definition, eg. as part of makeTail()
-  assert not p.isNil
-  assert p.kind == nnkProcDef
-  e.store.add p

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -62,32 +62,11 @@ proc root*(e: Env): NimNode =
     r = r.parent
   result = r.inherits
 
-when cpsTrace:
-  proc addTrace(e: Env; n: NimNode): NimNode =
-    if n.isNil or n.kind == nnkNilLit: return
-    # XXX: this doesn't work, sadly
-    #discard bindSym("init" & $e.root, rule = brForceOpen)
-    let info = lineInfoObj(n)
-    var identity =
-      if e.camefrom.isNil or e.camefrom.isEmpty:
-        "nil"
-      else:
-        repr(e.camefrom.returnTo)
-    identity.add "(" & repr(e.identity) & ")"
-    result = newCall(ident("init"), n, identity.newLit,
-                     info.filename.newLit,
-                     info.line.newLit,
-                     info.column.newLit)
-
 proc castToRoot(e: Env; n: NimNode): NimNode =
-  result = newTree(nnkCall, e.root, n)
-  when cpsTrace:
-    result = e.addTrace(result)
+  newTree(nnkCall, e.root, n)
 
 proc castToChild(e: Env; n: NimNode): NimNode =
-  when cpsTrace:
-    var n = e.addTrace(n)
-  result = newTree(nnkCall, e.identity, n)
+  newTree(nnkCall, e.identity, n)
 
 proc maybeConvertToRoot*(e: Env; locals: NimNode): NimNode =
   ## add an Obj(foo: bar).Other conversion if necessary

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -380,11 +380,14 @@ proc continuationReturnValue*(e: Env; goto: NimNode): NimNode =
   ## returns the appropriate target of a `return` statement in a CPS
   ## procedure that may (and may not) have a continuation instantiated yet.
   if e.first.isNil or e.first.isEmpty:
-    result = e.maybeConvertToRoot:
-      e.newContinuation goto
+    when false:
+      result = e.maybeConvertToRoot:
+        e.newContinuation goto
+    else:
+      error "this code path is deprecated because i'm lazy"
   else:
-    result = newStmtList()
-    result.add newAssignment(newDotExpr(e.first, e.fn), goto)
+    result = newStmtList:
+      newAssignment(newDotExpr(e.first, e.fn), goto)
     result.add e.first
 
 proc rewriteReturn*(e: var Env; n: NimNode): NimNode =

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -39,3 +39,12 @@ proc hook*(hook: Hook; n: NimNode): NimNode =
   of Trace:
     # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
     newCall(ident $hook, newLit(repr n.name), makeLineInfo n.lineInfoObj)
+
+proc hook*(hook: Hook; c: NimNode; n: NimNode): NimNode =
+  ## execute the given hook on the given node; `c` is likely a continuation
+  case hook
+  of Trace:
+    # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
+    newCall(ident $hook, c, newLit(repr n.name), makeLineInfo n.lineInfoObj)
+  else:
+    n.errorAst "the " & $hook & " hook doesn't take two arguments"

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -6,6 +6,8 @@ type
   Hook* = enum
     Coop = "coop"
     Trace = "trace"
+    Alloc = "alloc"
+    Dealloc = "dealloc"
 
 proc introduce*(hook: Hook; n: NimNode) =
   ## introduce a hook into the given scope whatfer later use therein
@@ -33,8 +35,8 @@ proc makeLineInfo(n: LineInfo): NimNode =
 proc hook*(hook: Hook; n: NimNode): NimNode =
   ## execute the given hook on the given node
   case hook
-  of Coop:
-    # coop(continuation)
+  of Coop, Alloc, Dealloc:
+    # hook(continuation)
     newCall(ident $hook, n)
   of Trace:
     # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -1,0 +1,41 @@
+import std/macros
+
+import cps/spec
+
+type
+  Hook* = enum
+    Coop = "coop"
+    Trace = "trace"
+
+proc introduce*(hook: Hook; n: NimNode) =
+  ## introduce a hook into the given scope whatfer later use therein
+  var n = n
+  case n.kind
+  of nnkStmtList:
+    n.insert(0, nnkMixinStmt.newTree ident($hook))
+  of nnkProcDef:
+    introduce hook, n.body       # TODO: maybe some pragmas at some point?
+  else:
+    n.insert(0, n.errorAst "you cannot add a " & $hook & " to a " & $n.kind)
+
+proc introduce*(n: NimNode; hooks: set[Hook]) =
+  ## convenience to introduce a set of hooks
+  for hook in hooks.items:
+    hook.introduce n
+
+proc makeLineInfo(n: LineInfo): NimNode =
+  ## turn a compile-time LineInfo object into a runtime LineInfo object
+  result = nnkObjConstr.newTree bindSym"LineInfo"
+  result.add newColonExpr(ident"filename", n.filename.newLit)
+  result.add newColonExpr(ident"line", n.line.newLit)
+  result.add newColonExpr(ident"column", n.column.newLit)
+
+proc hook*(hook: Hook; n: NimNode): NimNode =
+  ## execute the given hook on the given node
+  case hook
+  of Coop:
+    # coop(continuation)
+    newCall(ident $hook, n)
+  of Trace:
+    # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
+    newCall(ident $hook, newLit(repr n.name), makeLineInfo n.lineInfoObj)

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -41,14 +41,16 @@ proc hook*(hook: Hook; n: NimNode): NimNode =
   of Trace:
     # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
     newCall(ident $hook, newLit(repr n.name), makeLineInfo n.lineInfoObj)
-  of Dealloc:
-    newStmtList [newCall(ident $hook, n), newNilLit()]
+  else:
+    n.errorAst "the " & $hook & " hook doesn't take one argument"
 
-proc hook*(hook: Hook; c: NimNode; n: NimNode): NimNode =
-  ## execute the given hook on the given node; `c` is likely a continuation
+proc hook*(hook: Hook; a: NimNode; b: NimNode): NimNode =
+  ## execute the given hook with two arguments
   case hook
   of Trace:
     # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
-    newCall(ident $hook, c, newLit(repr n.name), makeLineInfo n.lineInfoObj)
+    newCall(ident $hook, a, newLit(repr b.name), makeLineInfo b.lineInfoObj)
+  of Dealloc:
+    newStmtList [newCall(ident $hook, a, b), newNilLit()]
   else:
-    n.errorAst "the " & $hook & " hook doesn't take two arguments"
+    b.errorAst "the " & $hook & " hook doesn't take two arguments"

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -35,12 +35,14 @@ proc makeLineInfo(n: LineInfo): NimNode =
 proc hook*(hook: Hook; n: NimNode): NimNode =
   ## execute the given hook on the given node
   case hook
-  of Coop, Alloc, Dealloc:
+  of Coop, Alloc:
     # hook(continuation)
     newCall(ident $hook, n)
   of Trace:
     # trace("whileLoop_2323", LineInfo(filename: "...", line: 23, column: 44))
     newCall(ident $hook, newLit(repr n.name), makeLineInfo n.lineInfoObj)
+  of Dealloc:
+    newStmtList [newCall(ident $hook, n), newNilLit()]
 
 proc hook*(hook: Hook; c: NimNode; n: NimNode): NimNode =
   ## execute the given hook on the given node; `c` is likely a continuation

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -11,7 +11,6 @@ when (NimMajor, NimMinor) < (1, 3):
 
 const
   cpsDebug* {.booldefine.} = false       ## produce gratuitous output
-  cpsTrace* {.booldefine.} = false       ## store "stack" traces
   comments* = cpsDebug         ## embed comments within the transformation
 
 template cpsLift*() {.pragma.}          ## lift this proc|type

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -22,14 +22,15 @@ template cpsBreak*(label: typed = nil) {.pragma.} ## this is a break statement i
 template cpsContinue*() {.pragma.}      ## this is a continue statement in a cps block
 
 type
-  NodeFilter* = proc(n: NimNode): NimNode
-
-  Continuation* = concept c
+  ContinuationProc*[T] = proc(c: T): T {.nimcall.}
+  Continuation* = concept c ##
+    ## All continuation types must match this `Continuation` concept
+    ## in order to be used by the `.cps.` macro.
     c.fn is ContinuationProc[Continuation]
     c is ref object
     c of RootObj
 
-  ContinuationProc*[T] = proc(c: T): T {.nimcall.}
+  NodeFilter* = proc(n: NimNode): NimNode
 
   Pair* = tuple
     key: NimNode

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -6,8 +6,8 @@ boring utilities likely useful to multiple pieces of cps machinery
 
 import std/[hashes, sequtils, macros]
 
-when (NimMajor, NimMinor) < (1, 3):
-  {.fatal: "requires nim-1.3".}
+when (NimMajor, NimMinor) < (1, 5):
+  {.fatal: "requires nim-1.5".}
 
 const
   cpsDebug* {.booldefine.} = false       ## produce gratuitous output

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -15,6 +15,7 @@ const
 
 template cpsLift*() {.pragma.}          ## lift this proc|type
 template cpsCall*() {.pragma.}          ## a cps call
+template cpsVoodooCall*() {.pragma.}    ## a voodoo call
 template cpsCall*(n: typed) {.pragma.}  ## redirection
 template cpsPending*() {.pragma.}       ## this is the last continuation
 template cpsBreak*(label: typed = nil) {.pragma.} ## this is a break statement in a cps block

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -335,7 +335,7 @@ proc saften(parent: var Env; n: NimNode): NimNode =
     if nc.isNil:
       result.add nc
       continue
-    
+
     # if it's a cps call,
     if nc.isCpsCall:
       let jumpCall = newCall(bindSym"cpsJump")
@@ -502,8 +502,7 @@ macro cpsResolver(T: typed, n: typed): untyped =
   # replace all `pending` with the end of continuation
   result = replacePending n:
     tailCall cont:
-      hook Dealloc:
-        cont
+      Dealloc.hook(T, cont)
   result = danglingCheck result
   result = workaroundRewrites result
 
@@ -614,7 +613,7 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
 
   # run other stages
   n.addPragma bindSym"cpsFloater"
-  n.addPragma nnkExprColonExpr.newTree(bindSym"cpsResolver", T)
+  n.addPragma nnkExprColonExpr.newTree(bindSym"cpsResolver", env.identity)
 
   # "encouraging" a write of the current accumulating type
   env = env.storeType(force = off)

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -136,6 +136,7 @@ proc makeContProc(name, cont, source: NimNode): NimNode =
     result.body.add newCpsPending()
   # tell cpsFloater that we want this to be lifted to the top-level
   result.addPragma bindSym"cpsLift"
+  result.addPragma ident"nimcall"
 
 func tailCall(cont: NimNode; to: NimNode; jump: NimNode = nil): NimNode =
   ## a tail call to `to` with `cont` as the continuation; if the `jump`

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -113,7 +113,7 @@ proc makeContProc(name, cont, source: NimNode): NimNode =
   result = newProc(name, [contType, newIdentDefs(contParam, contType)])
   result.copyLineInfo source        # grab lineinfo from the source body
   result.body = newStmtList()       # start with an empty body
-  result.introduce {Coop, Trace, Dealloc}    # mix any hooks in
+  result.introduce {Coop, Trace, Alloc, Dealloc}    # mix any hooks in
   result.body.add:                  # insert a hook ahead of the source,
     Trace.hook contParam, result    # hooking against the proc (minus body)
   result.body.add:                  # perform convenience rewrites on source
@@ -570,7 +570,7 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
   n.params = nnkFormalParams.newTree(T, env.firstDef)
 
   var body = newStmtList()     # a statement list will wrap the body
-  body.introduce {Trace}       # prepare to add a trace hook
+  body.introduce {Trace, Alloc, Dealloc}   # prepare hooks
   body.add:
     Trace.hook env.first, n    # hooking against the proc (minus cloned body)
   body.add n.body              # add in the cloned body of the original proc

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -491,7 +491,9 @@ macro cpsResolver(T: typed, n: typed): untyped =
   let n = normalizingRewrites n
   # replace all `pending` with the end of continuation
   result = replacePending n:
-    tailCall(cont, newNilLit())
+    tailCall cont:
+      hook Dealloc:
+        cont
   result = danglingCheck result
   result = workaroundRewrites result
 

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -463,6 +463,7 @@ proc cloneProc(n: NimNode, body: NimNode = nil): NimNode =
     newEmptyNode(),
     newEmptyNode(),
     if body == nil: copy n.body else: body)
+  result.copyLineInfo n
 
 proc replacePending(n, replacement: NimNode): NimNode =
   ## Replace cpsPending annotations with something else, usually

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -157,7 +157,7 @@ proc makeContProc(name, cont, source: NimNode): NimNode =
   result.body.add:                  # perform convenience rewrites on source
     normalizingRewrites newStmtList(source)
   result.body.last.insert 0:        # insert a hook ahead of the source,
-    Trace.hook result               # hooking against the proc as a whole
+    Trace.hook contParam, result    # hooking against the proc as a whole
 
   # replace `cont` in the body with the parameter of the new proc
   result.body = resym(result.body, cont, contParam)

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -554,7 +554,7 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
   booty.body.doc "This is the bootstrap to go from Nim-land to CPS-land"
   booty.introduce {Alloc, Dealloc}    # we may actually dealloc here
   booty.body.add:
-    newAssignment(ident"result", env.newContinuation booty.name)
+    env.createContinuation booty.name
 
   # we can't mutate typed nodes, so copy ourselves
   n = cloneProc n

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -113,7 +113,7 @@ proc makeContProc(name, cont, source: NimNode): NimNode =
   result = newProc(name, [contType, newIdentDefs(contParam, contType)])
   result.copyLineInfo source        # grab lineinfo from the source body
   result.body = newStmtList()       # start with an empty body
-  result.introduce {Coop, Trace}    # mix any hooks in, however we do that
+  result.introduce {Coop, Trace, Dealloc}    # mix any hooks in
   result.body.add:                  # insert a hook ahead of the source,
     Trace.hook contParam, result    # hooking against the proc (minus body)
   result.body.add:                  # perform convenience rewrites on source
@@ -552,6 +552,7 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
   var booty = cloneProc(n, newStmtList())
   booty.params[0] = T
   booty.body.doc "This is the bootstrap to go from Nim-land to CPS-land"
+  booty.introduce {Alloc, Dealloc}    # we may actually dealloc here
   booty.body.add:
     newAssignment(ident"result", env.newContinuation booty.name)
 

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -16,6 +16,15 @@ proc isCpsCall(n: NimNode): bool =
       if not callee.isNil and callee.kind == nnkSym:
         result = callee.getImpl.hasPragma("cpsCall")
 
+proc isVoodooCall(n: NimNode): bool =
+  ## true if this node holds a call to a cps procedure
+  if n != nil and len(n) > 0:
+    if n.kind in nnkCallKinds:
+      let callee = n[0]
+      # all cpsCall are normal functions called via a generated symbol
+      if not callee.isNil and callee.kind == nnkSym:
+        result = callee.getImpl.hasPragma("cpsVoodooCall")
+
 proc firstReturn(p: NimNode): NimNode =
   ## find the first return statement within statement lists, or nil
   case p.kind
@@ -326,6 +335,7 @@ proc saften(parent: var Env; n: NimNode): NimNode =
     if nc.isNil:
       result.add nc
       continue
+    
     # if it's a cps call,
     if nc.isCpsCall:
       let jumpCall = newCall(bindSym"cpsJump")
@@ -523,6 +533,16 @@ macro cpsFloater(n: typed): untyped =
 
   #debug(".cpsFloater.", result, Transformed, n)
 
+proc rewriteVoodoo(n: NimNode, env: Env): NimNode =
+  ## Rewrite non-yielding cpsCall calls by inserting the continuation as
+  ## the first argument
+  proc aux(n: NimNode): NimNode =
+    if n.isVoodooCall:
+      result = n.copyNimTree
+      result[0] = desym result[0]
+      result.insert(1, env.first)
+  n.filter(aux)
+
 proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
   ## rewrite the target procedure in Continuation-Passing Style
 
@@ -582,6 +602,9 @@ proc cpsXfrmProc*(T: NimNode, n: NimNode): NimNode =
 
   # transform defers
   n.body = rewriteDefer n.body
+
+  # rewrite non-yielding cps calls
+  n.body = rewriteVoodoo(n.body, env)
 
   # ensaftening the proc's body
   n.body = env.saften(n.body)

--- a/stash/coroutine.nim
+++ b/stash/coroutine.nim
@@ -2,76 +2,49 @@
 import cps, options, deques
 
 type
-  Cont = ref object of RootObj
-    fn*: proc(c: Cont): Cont {.nimcall.}
-
-  Coro = ref object
-    c: Cont
-    sIn: string
-
-  CoroFn = proc(app: App, coro: Coro): Cont
-
-  App = ref object
-    coro1: Coro
-    coro2: Coro
+  Coroutine = ref object of RootObj
+    fn*: proc(c: Coroutine): Coroutine {.nimcall.}
+    s: int
+    cResume: Coroutine
 
 
-proc jield(c: Cont, coro: Coro): Cont {.cpsMagic.} =
-  coro.c = c
- 
-proc resume(coro: Coro) =
-  var c = coro.c
-  while c.running:
-    c = c.fn(c)
+proc tramp(c: Coroutine): Coroutine {.discardable.}  =
+  result = c
+  while result.running:
+    result = c.fn(result)
 
-proc send(coro: Coro, s: string) =
-  coro.sIn = s
-  coro.resume()
+proc recv(c: Coroutine): int {.cpsMagic.} =
+  c.s
 
-proc recv(coro: Coro): string =
-  coro.sIn
+proc jield(c: Coroutine): Coroutine {.cpsMagic.} =
+  c.cResume = c
 
-proc newCoro(app: App, fn: CoroFn): Coro =
-  let coro = Coro()
-  coro.c = fn(app, coro)
-  coro.resume()
-  coro
+proc send(c: Coroutine, s: int) =
+  c.s = s
+  tramp c.cResume
 
+# This coroutine doubles numbers
 
-
-# This coro receives strings, accumulates and splits by newline,
-# and send the lines to coro2
-proc fn_coro1(app: App, coro: Coro) {.cps:Cont} =
-  var buf = ""
+proc fn_coro1(dest: Coroutine, dummy: bool) {.cps:Coroutine.} =
   while true:
-    coro.jield()
-    let s = coro.recv()
-    for c in s:
-      if c == '\n':
-        echo "tx ", buf
-        app.coro2.send(buf)
-        buf = ""
-      else:
-        buf = buf & c
+    jield()
+    let v = recv()
+    dest.send(v * 2)
 
-# This coro receives strings from coro1 and prints them
-proc fn_coro2(app: App, coro: Coro) {.cps:Cont} =
+# This coro receives ints from coro1 and prints them
+
+proc fn_coro2() {.cps:Coroutine.} =
   while true:
-    coro.jield()
-    let s = coro.recv()
-    echo "rx ", s
+    jield()
+    let val = recv()
+    echo val
 
 
-let app = App()
+let coro2 = fn_coro2()
+let coro1 = fn_coro1(coro2, true)
 
-app.coro1 = app.newCoro(fn_coro1)
-app.coro1.resume()
+coro1.tramp()
+coro2.tramp()
 
-app.coro2 = app.newCoro(fn_coro2)
-app.coro2.resume()
-
-while true:
-  app.coro1.send("line ")
-  app.coro1.send("one\nline ")
-  app.coro1.send("two\n")
-
+for i in 1..10:
+  coro1.send(i)

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1135,12 +1135,15 @@ suite "tasteful tests":
     ## custom deallocators
     var r = 0
     proc dealloc(c: Cont) =
+      check r == 0
       inc r
 
     proc foo(x: int) {.cps: Cont.} =
+      check r == 0
       check x == 3
       noop()
       check x == 3
+      check r == 0
 
     trampoline foo(3)
     check r == 1, "bzzzt"

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1,7 +1,7 @@
+import std/macros
+import std/strutils
 import balls
-
 import cps
-
 import foreign
 
 type
@@ -1090,3 +1090,27 @@ suite "tasteful tests":
 
     trampoline foo()
     check r == 7
+
+  block:
+    ## control-flow tracing
+
+    var found: seq[string]
+    proc trace(name: string; info: LineInfo) =
+      let sub = name.split("_", maxsplit=1)[0]
+      found.add sub
+      found.add $info.column
+
+    proc foo() {.cps: Cont.} =
+      var i = 0
+      while i < 3:
+        noop()
+        inc i
+        if i == 0:
+          continue
+        if i > 2:
+          break
+
+    trampoline foo()
+    check found == [ "whileLoop", "24", "afterCall", "8",
+                     "whileLoop", "24", "afterCall", "8",
+                     "whileLoop", "24", "afterCall", "8", ]

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1093,7 +1093,6 @@ suite "tasteful tests":
 
   block:
     ## control-flow tracing
-
     var found: seq[string]
     proc trace(c: Cont; name: string; info: LineInfo) =
       let sub = name.split("_", maxsplit=1)[0]
@@ -1116,3 +1115,18 @@ suite "tasteful tests":
                      "whileLoop", "24", "16", "afterCall", "8", "16",
                      "whileLoop", "24", "16", "afterCall", "8", "16",
                      "whileLoop", "24", "16", "afterCall", "8", "16", ]
+
+  block:
+    ## custom allocators
+    var r = 0
+    proc alloc[Cont](c: typedesc[Cont]): c =
+      inc r
+      new c
+
+    proc foo(x: int) {.cps: Cont.} =
+      check x == 3
+      noop()
+      check x == 3
+
+    trampoline foo(3)
+    check r == 1, "bzzzt"

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1130,3 +1130,17 @@ suite "tasteful tests":
 
     trampoline foo(3)
     check r == 1, "bzzzt"
+
+  block:
+    ## custom deallocators
+    var r = 0
+    proc dealloc(c: Cont) =
+      inc r
+
+    proc foo(x: int) {.cps: Cont.} =
+      check x == 3
+      noop()
+      check x == 3
+
+    trampoline foo(3)
+    check r == 1, "bzzzt"

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1095,10 +1095,11 @@ suite "tasteful tests":
     ## control-flow tracing
 
     var found: seq[string]
-    proc trace(name: string; info: LineInfo) =
+    proc trace(c: Cont; name: string; info: LineInfo) =
       let sub = name.split("_", maxsplit=1)[0]
       found.add sub
       found.add $info.column
+      found.add $sizeof(c[])
 
     proc foo() {.cps: Cont.} =
       var i = 0
@@ -1111,6 +1112,6 @@ suite "tasteful tests":
           break
 
     trampoline foo()
-    check found == [ "whileLoop", "24", "afterCall", "8",
-                     "whileLoop", "24", "afterCall", "8",
-                     "whileLoop", "24", "afterCall", "8", ]
+    check found == [ "whileLoop", "24", "16", "afterCall", "8", "16",
+                     "whileLoop", "24", "16", "afterCall", "8", "16",
+                     "whileLoop", "24", "16", "afterCall", "8", "16", ]

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1112,6 +1112,7 @@ suite "tasteful tests":
           break
 
     trampoline foo()
-    check found == [ "whileLoop", "24", "16", "afterCall", "8", "16",
+    check found == [ "foo", "4", "16",
+                     "whileLoop", "24", "16", "afterCall", "8", "16",
                      "whileLoop", "24", "16", "afterCall", "8", "16",
                      "whileLoop", "24", "16", "afterCall", "8", "16", ]

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1134,7 +1134,7 @@ suite "tasteful tests":
   block:
     ## custom deallocators
     var r = 0
-    proc dealloc(c: Cont) =
+    proc dealloc[T: Cont](t: typedesc; c: sink T) =
       check r == 0
       inc r
 

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1119,7 +1119,7 @@ suite "tasteful tests":
   block:
     ## custom allocators
     var r = 0
-    proc alloc[Cont](c: typedesc[Cont]): c =
+    proc alloc[T: Cont](c: typedesc[T]): c =
       inc r
       new c
 


### PR DESCRIPTION
By formalized, I think @zevv just wants to make the stuff discoverable and not too adhoc.  This does that, but I'm not sure how useful it is.

I think the `trace()` might want to take the continuation as input as well, so that could mess with the invocation somewhat.  Maybe we can standardize on just a few signatures for hooks...