### PR TITLE
cps/xfrm: cleanup exception rewrite and fix bugs

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -645,3 +645,9 @@ proc getContSym*(n: NimNode): NimNode =
     n.params[1][0]
   else:
     nil
+
+proc isScopeExit*(n: NimNode): bool =
+  ## Return whether the given node signify a scope exit
+  ##
+  ## TODO: Handle early exit (ie. `c.fn = nil; return`)
+  n.isCpsPending or n.isCpsBreak or n.isCpsContinue

--- a/cps/xfrm.nim
+++ b/cps/xfrm.nim
@@ -322,6 +322,70 @@ macro cpsWhile(cont, cond, n: typed): untyped =
 
   #debug("cpsWhile", result, Transformed, cond)
 
+proc rewriteExcept(cont, ex, n: NimNode): tuple[cont, excpt: NimNode] =
+  ## Rewrite the exception branch `n` to use `ex` as the "current" exception
+  ## and move its body into a continuation
+  doAssert n.kind == nnkExceptBranch
+
+  result.excpt = copyNimNode n
+
+  var body = newStmtList(n.last)
+  # this is `except Type: body`
+  if n.len > 1:
+    # this is `except Type as e: body`
+    if n[0].kind == nnkInfix:
+      # replace all occurance of `e` with `ex`
+      body = body.resym(n[0][2], ex)
+
+      # add `Type` to our new except clause
+      result.excpt.add n[0][1]
+    else:
+      # add `Type`
+      result.excpt.add n[0]
+
+  proc setException(contSym, n: NimNode): NimNode =
+    ## Set the exception to `ex` before running any other code
+    proc setContException(n: NimNode): NimNode =
+      ## If `n` is a continuation, set the exception to `ex` before
+      ## running any other code
+      # XXX: need a way to prevent multiple insertions of this
+      if n.isCpsCont:
+        result = n
+        result.body = setException(getContSym(n), result.body)
+
+    result = newStmtList():
+      newCall(bindSym"setCurrentException", ex.resym(cont, contSym))
+
+    for i in n.items:
+      result.add i.filter(setContException)
+
+    proc consumeException(n: NimNode): NimNode =
+      ## Prepend all cpsPending with `setCurrentException nil`
+      # XXX: need a way to prevent multiple insertion of this
+      if n.isCpsPending:
+        result = newStmtList()
+        # set the global exception to nil
+        result.add newCall(bindSym"setCurrentException", newNilLit())
+        # set our exception symbol to nil too
+        result.add newAssignment(ex.resym(cont, contSym), newNilLit())
+        result.add n
+
+    result = result.filter(consumeException)
+
+  # move the exception body into a handler
+  result.cont = makeContProc(genSym(nskProc, "except"), cont):
+    # rewrite the exception body to be continuation-aware
+    setException(cont, body)
+
+  # create the new body for the except clause
+  result.excpt.add newStmtList()
+  # capture the exception into the continuation
+  result.excpt.last.add newAssignment(ex, newCall(bindSym"getCurrentException"))
+  # add the tail call to the created handler
+  result.excpt.last.add tailCall(cont, result.cont.name)
+
+  discard "workaround for NimNode.add() returning something"
+
 macro cpsTryExcept(cont, ex, n: typed): untyped =
   ## A try statement tainted by a `cpsJump` and
   ## may require a jump to enter any handler.
@@ -349,47 +413,15 @@ macro cpsTryExcept(cont, ex, n: typed): untyped =
   # Turn each handler branch into a continuation leg
   # For finally we stash it into a variable for rewrite later
   for i in 1 ..< n.len:
-    case n[i].kind
+    let child = n[i]
+    case child.kind
     of nnkExceptBranch:
-      let newExcept = copyNimNode n[i]
-      # this is `except Type: body`
-      if n[i].len > 1:
-        # add `Type` or `Type as e`
-        newExcept.add n[i][0]
+      let (cont, excpt) = rewriteExcept(cont, ex, child)
+      # push the handler continuation to the top
+      result.add cont
 
-      # create a new body
-      newExcept.add newStmtList()
-
-      # get old handler body
-      var handlerBody = newStmtList(n[i].last)
-
-      # if it's a `except Type as e`
-      if newExcept.len > 1 and newExcept[0].kind == nnkInfix:
-        # assign the exception to `ex`
-        let exSym = newExcept[0][2]
-        # replace all occurance of `exSym` with `ex`
-        handlerBody = handlerBody.resym(exSym, ex)
-
-        # rewrite this into `except Type`
-        newExcept[0] = newExcept[0][1]
-
-      # assign the exception into `ex`
-      newExcept.last.add:
-        newAssignment(ex, newCall(bindSym"getCurrentException"))
-
-      # set exception to the stashed one before executing any other code
-      handlerBody.insert(0):
-        newCall(bindSym"setCurrentException", ex)
-
-      # turn the exception body into a continuation
-      let handler = makeContProc(genSym(nskProc, "except"), cont, handlerBody)
-      # add the continuation to the top
-      result.add handler
-      # add a tail to the new continuation in the except branch
-      newExcept.last.add tailCall(cont, handler.name)
-
-      # add this into the template
-      tryTemplate.add newExcept
+      # add the rewritten except branch to the template
+      tryTemplate.add excpt
     else: result.add errorAst(n[i], "unexpected node in cpsTryExcept")
 
   proc wrapTry(contSym, n: NimNode): NimNode =

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -19,6 +19,8 @@ proc trampoline(c: Cont) =
     # pretends that an exception is raised and handled elsewhere
     setCurrentException(nil)
     c = c.fn(c)
+    # no exception should leak outside of the continuation
+    check getCurrentException().isNil
     inc jumps
     if jumps > 1000:
       raise InfiniteLoop.newException: $jumps & " iterations"

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -16,6 +16,8 @@ proc trampoline(c: Cont) =
   jumps = 0
   var c = c
   while c.running:
+    # pretends that an exception is raised and handled elsewhere
+    setCurrentException(nil)
     c = c.fn(c)
     inc jumps
     if jumps > 1000:


### PR DESCRIPTION
Fixed one main issue where the "current" exception is not refreshed
every bounce and that the exception is not voided after completion
of the except clauses.

Also moved the except rewrite outside of `cpsTryExcept`.

Need more tests.