### PR TITLE
cps/xfrm: add a pass to rewrite cps exprs

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -653,9 +653,9 @@ proc isScopeExit*(n: NimNode): bool =
   n.isCpsPending or n.isCpsBreak or n.isCpsContinue
 
 proc makeTempVar*(typ: NimNode): tuple[sym: NimNode, decl: NimNode] =
-  # Make a temporary variable with type `typ`
-  #
-  # `sym` is the symbol of the variable, and `decl` is the declaration
+  ## Make a temporary variable with type `typ`
+  ##
+  ## `sym` is the symbol of the variable, and `decl` is the declaration
   result.sym = genSym(nskVar)
   result.decl =
     nnkVarSection.newTree:

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -651,3 +651,12 @@ proc isScopeExit*(n: NimNode): bool =
   ##
   ## TODO: Handle early exit (ie. `c.fn = nil; return`)
   n.isCpsPending or n.isCpsBreak or n.isCpsContinue
+
+proc makeTempVar*(typ: NimNode): tuple[sym: NimNode, decl: NimNode] =
+  # Make a temporary variable with type `typ`
+  #
+  # `sym` is the symbol of the variable, and `decl` is the declaration
+  result.sym = genSym(nskVar)
+  result.decl =
+    nnkVarSection.newTree:
+      newIdentDefs(result.sym, typ)

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1249,6 +1249,25 @@ suite "tasteful tests":
     check r == 4
 
   block:
+    ## a case statement with elif branches evaluating a cps expression
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      case (noop(); inc r; true)
+      of false:
+        fail "this branch should not be taken"
+      elif (noop(); inc r; false):
+        fail "this branch should not be taken"
+      elif (noop(); inc r; true):
+        inc r
+      else:
+        fail "this branch should not be taken"
+      inc r
+
+    trampoline foo()
+    check r == 6
+
+  block:
     ## a if statement evaluating a cps expression
     r = 0
     proc foo() {.cps: Cont.} =

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -1225,13 +1225,20 @@ suite "tasteful tests":
   block:
     ## a call with cps expression being a parameter
     r = 0
+
+    proc bar(x, y, z: int) =
+      check x == 3
+      check y == 1
+      check z == 2
+
     proc foo() {.cps: Cont.} =
       inc r
-      check (noop(); inc r; true)
+      var x = 3
+      bar(x, (noop(); dec(x, 2); x), (inc x; x))
       inc r
 
     trampoline foo()
-    check r == 3
+    check r == 2
 
   block:
     ## a case statement evaluating a cps expression


### PR DESCRIPTION
Flatten expressions with cps calls in it so that it can be rewritten.

Very experimental, need a lot of cleanup and revision to the approach.