### PR TITLE
remove rewrites.cloneProc and use ProcDef fields

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -181,11 +181,6 @@ proc getContSym*(n: NimNode): NimNode =
   else:
     nil
 
-proc cloneProc*(n: NimNode, body: NimNode = nil): NimNode {.deprecated.} =
-  ## create a copy of a typed proc which satisfies the compiler
-  assert n.kind == nnkProcDef
-  cProcDefToNimNode(clone(n.ProcDef, body))
-
 proc isScopeExit*(n: NimNode): bool =
   ## Return whether the given node signify a scope exit
   ##

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -541,10 +541,10 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
 
   # creating the env with the continuation type,
   # and adding proc parameters to the env
-  var env = newEnv(ident"continuation", types, T, n.params[0])
+  var env = newEnv(ident"continuation", types, T, n.returnParam)
 
   # add parameters into the environment
-  for defs in n.params[1 .. ^1]:
+  for defs in n.callingParams:
     if defs[1].kind == nnkVarTy:
       error "cps does not support var parameters", n
     env.localSection(defs)
@@ -553,7 +553,7 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
   let name = genSym(nskProc, $n.name)
 
   # we can't mutate typed nodes, so copy ourselves
-  n = n.clone
+  n = clone(n)
 
   # the whelp is a limited bootstrap that merely makes
   # the continuation without invoking it in a trampoline


### PR DESCRIPTION
- removes cloneProc usage by introduce ProcDef in more places
- introduce callingParams iterator, for passed in parameter defintions
- create desym operation for ProcDef, which also maintains the invariant
- use returnParam field more pervasively
- setting the returnParam now guarantees the normalized invariant