### PR TITLE
"complicated" naked returns were polluting the transform

### DIFF
--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -379,9 +379,13 @@ proc annotate(parent: var Env; n: NimNode): NimNode =
     case nc.kind
     of nnkReturnStmt:
       # add a return statement with a potential result assignment
-      # stored in the environment
-      return makeReturn result:
-        env.rewriteReturn nc
+      # stored in the environment; note that we're adding a new
+      # return statement without regard to the contents of `result`
+      # because it may hold, eg. `ElifBranch ...` or similar.
+      result.add:
+        makeReturn:
+          env.rewriteReturn nc
+      return
 
     of nnkVarSection, nnkLetSection:
       let section = expectVarLet(nc)

--- a/tests/preamble.nim
+++ b/tests/preamble.nim
@@ -53,7 +53,7 @@ suite "basic testing assumptions":
     trampoline whelp(foo())
     check r == 2, "who let the smoke out?"
 
-template shouldRun(wanted: int; body: untyped) =
+template shouldRun(wanted: int; body: untyped) {.used.} =
   var measured {.inject.} = 0
   try:
     body

--- a/tests/preamble.nim
+++ b/tests/preamble.nim
@@ -58,7 +58,7 @@ template shouldRun(wanted: int; body: untyped) {.used.} =
   try:
     body
   finally:
-    check measured != wanted:
+    check measured == wanted:
       if wanted == 0:         "oops; continuation ran"
       elif measured == 0:     "continuation never ran"
       elif measured > wanted: "continuation ran too often"

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -147,26 +147,6 @@ suite "tasteful tests":
     check r == 9
 
   block:
-    ## local assignment to a continuation return value
-    when true:
-      skip"pending discussion #28"
-    else:
-      r = 0
-      proc bar(a: int): int {.cps: Cont.} =
-        inc r
-        noop()
-        return a * 2
-
-      proc foo() {.cps: Cont.} =
-        inc r
-        let x = int bar(4)
-        inc r
-        check x == 8
-
-      foo()
-      check r == 3
-
-  block:
     ## calling a function pointer inside an object works
     type Fn = object
       fn: proc(i: int): int
@@ -419,36 +399,6 @@ suite "tasteful tests":
 
     foo()
     check r == 1
-
-  block:
-    ## continuations can return values via bootstrap or whelp
-    r = 0
-    proc foo(x: int): int {.cps: Cont.} =
-      noop()
-      inc r
-      return x * x
-
-    let x = foo(3)
-    check r == 1
-    check x == 9
-    var c = whelp foo(5)
-    trampoline c
-    check r == 2
-
-  block:
-    ## assignments to the special result symbol work
-    r = 0
-    proc foo(x: int): int {.cps: Cont.} =
-      noop()
-      inc r
-      result = x * x
-
-    let x = foo(3)
-    check r == 1
-    check x == 9
-    var c = whelp foo(5)
-    trampoline c
-    check r == 2
 
   block:
     ## implicit up-casting

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -69,3 +69,13 @@ suite "returns and results":
 
       var c = whelp foo(5)
       trampoline c
+
+  block:
+    ## naked returns in continuations are fine
+    var k = newKiller 1
+    proc foo() {.cps: Cont.} =
+      noop()
+      step 1
+      return
+
+    foo()

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -1,0 +1,74 @@
+import std/macros
+import std/strutils
+import balls
+import cps
+
+include preamble
+import killer
+
+suite "returns and results":
+
+  block:
+    ## local assignment to a continuation return value
+    when true:
+      skip"pending discussion #28"
+    else:
+      r = 0
+      proc bar(a: int): int {.cps: Cont.} =
+        inc r
+        noop()
+        return a * 2
+
+      proc foo() {.cps: Cont.} =
+        inc r
+        let x = int bar(4)
+        inc r
+        check x == 8
+
+      foo()
+      check r == 3
+
+  block:
+    ## continuations can return values via bootstrap or whelp
+    var k = newKiller 1
+    proc foo(x: int): int {.cps: Cont.} =
+      noop()
+      step 1
+      return x * x
+
+    let x = foo(3)
+    check x == 9
+
+  block:
+    ## continuations can return values via whelp
+    skip "not a thing yet"
+    var k = newKiller 1
+    proc foo(x: int): int {.cps: Cont.} =
+      noop()
+      step 1
+      return x * x
+
+    var c = whelp foo(5)
+    trampoline c
+
+  block:
+    ## assignments to the special result symbol work
+    block:
+      var k = newKiller 1
+      proc foo(x: int): int {.cps: Cont.} =
+        noop()
+        step 1
+        result = x * x
+
+      let x = foo(3)
+      check x == 9
+
+    block:
+      var k = newKiller 1
+      proc foo(x: int): int {.cps: Cont.} =
+        noop()
+        step 1
+        result = x * x
+
+      var c = whelp foo(5)
+      trampoline c

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -71,11 +71,13 @@ suite "returns and results":
       trampoline c
 
   block:
-    ## naked returns in continuations are fine
+    ## naked returns in continuations with a complication are fine
     var k = newKiller 1
     proc foo() {.cps: Cont.} =
       noop()
       step 1
-      return
+      if true:
+        return
+      step 2
 
     foo()

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -10,26 +10,23 @@ suite "returns and results":
 
   block:
     ## local assignment to a continuation return value
-    when true:
-      skip"pending discussion #28"
-    else:
-      r = 0
+    skip"pending discussion #28":
+      var k = newKiller 3
       proc bar(a: int): int {.cps: Cont.} =
-        inc r
         noop()
+        step 2
         return a * 2
 
       proc foo() {.cps: Cont.} =
-        inc r
+        step 1
         let x = int bar(4)
-        inc r
+        step 3
         check x == 8
 
       foo()
-      check r == 3
 
   block:
-    ## continuations can return values via bootstrap or whelp
+    ## continuations can return values via bootstrap
     var k = newKiller 1
     proc foo(x: int): int {.cps: Cont.} =
       noop()


### PR DESCRIPTION
```nim
if true:
  return
```
was turning into
```
ifstmt
  stmtlist
    elif
      true
      return
```
and now it is, at worst,
```
ifstmt
  elif
    true
    stmtlist
      return
```