### PR TITLE
cps/transform: give the original symbol of the proc to booty

### DIFF
--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -538,7 +538,7 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
   ## rewrite the target procedure in Continuation-Passing Style
 
   # keep the original symbol of the proc
-  let prcSym = n[0]
+  let originalProcSym = n[0]
   # make the AST easier for us to consume
   var n = normalizeProcDef n
   # establish a new environment with the supplied continuation type;
@@ -581,7 +581,7 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
   # this is a workaround for nim bugs:
   # https://github.com/nim-lang/Nim/issues/18203 (used hints)
   # https://github.com/nim-lang/Nim/issues/18235 (export leaks)
-  booty.name = prcSym
+  booty.name = originalProcSym
 
   # now we'll reset the name of the new proc
   # XXX: not sure why we need to desym, but we have to or it won't be

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -577,7 +577,10 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
   booty.addPragma ident"cpsMustJump"
 
   # give the booty the sym we got from the original, which
-  # make the booty take the place of the original proc
+  # causes the bootstrap symbol to adopt the original procedure's symbol;
+  # this is a workaround for nim bugs:
+  # https://github.com/nim-lang/Nim/issues/18203 (used hints)
+  # https://github.com/nim-lang/Nim/issues/18235 (export leaks)
   booty.name = prcSym
 
   # now we'll reset the name of the new proc


### PR DESCRIPTION
This enables the booty to take the place of the original proc,
effectively working around nim-lang/Nim#18235