### PR TITLE
stack unwind in response to exceptions

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -130,13 +130,13 @@ macro whelp*(parent: Continuation; call: typed): untyped =
                   newCall(base, it))
 
 template head*[T: Continuation](first: T): T {.used.} =
-  ## This symbol may be reimplemented to configure a continuation
+  ## Reimplement this symbol to configure a continuation
   ## for use when there is no parent continuation available.
   ## The return value specifies the continuation.
   first
 
 proc tail*[T: Continuation](parent: Continuation; child: T): T {.used, inline.} =
-  ## This symbol may be reimplemented to configure a continuation for
+  ## Reimplement this symbol to configure a continuation for
   ## use when it has been instantiated from inside another continuation;
   ## currently, this means assigning the parent to the child's `mom`
   ## field. The return value specifies the child continuation.
@@ -148,30 +148,30 @@ proc tail*[T: Continuation](parent: Continuation; child: T): T {.used, inline.} 
   result.mom = parent
 
 template coop*[T: Continuation](c: T): T {.used.} =
-  ## This symbol may be reimplemented as a `.cpsMagic.` to introduce
+  ## Reimplement this symbol as a `.cpsMagic.` to introduce
   ## a cooperative yield at appropriate continuation exit points.
   ## The return value specifies the continuation.
   c
 
 template boot*[T: Continuation](c: T): T {.used.} =
-  ## This symbol may be reimplemented to refine a continuation after
+  ## Reimplement this symbol to refine a continuation after
   ## it has been allocated but before it is first run.
   ## The return value specifies the continuation.
   c
 
 template trace*(c: Continuation; fun: string; where: LineInfo) {.used.} =
-  ## This symbol may be reimplemented to introduce control-flow
+  ## Reimplement this symbol to introduce control-flow
   ## tracing of the entry to each continuation leg.
   discard
 
 proc alloc*[T: Continuation](root: typedesc[T]; c: typedesc): c {.used, inline.} =
-  ## This symbol may be reimplemented to customize continuation
+  ## Reimplement this symbol to customize continuation
   ## allocation.
   new c
 
 template dealloc*[T: Continuation](t: typedesc[T];
                                    c: sink Continuation) {.used.} =
-  ## This symbol may be reimplemented to customize continuation
+  ## Reimplement this symbol to customize continuation
   ## deallocation.
   discard
 

--- a/cps.nim
+++ b/cps.nim
@@ -218,3 +218,12 @@ template `()`(c: Continuation): untyped {.used.} =
   ## Returns the result, i.e. the return value, of a continuation.
   discard
 {.pop.}
+
+proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
+                                                                cpsMagic.} =
+  ## This symbol may be reimplemented to customize exception handling.
+  if c.mom.isNil:
+    raise e
+  else:
+    result = c.mom
+    result.ex = e

--- a/cps.nim
+++ b/cps.nim
@@ -1,11 +1,11 @@
 import std/[macros]
 import cps/[spec, transform, rewrites, hooks, exprs]
 export Continuation, ContinuationProc, State
-export cpsCall, cpsMagicCall, cpsVoodooCall, cpsMustJump
+export cpsCall, cpsMagicCall, cpsVoodooCall, cpsMustJump, cpsMagic
 
 # exporting some symbols that we had to bury for bindSym reasons
 from cps/returns import pass
-export pass, trampoline
+export pass, trampoline, unwind, handler
 
 # we only support arc/orc due to its eager expr evaluation qualities
 when not(defined(gcArc) or defined(gcOrc)):
@@ -75,44 +75,6 @@ macro cps*(T: typed, n: typed): untyped =
             n
     else:
       result = getAst(cpsTransform(T, n))
-
-proc makeErrorShim(n: NimNode): NimNode =
-  ## Upgrades a procedure to serve as a CPS primitive, generating
-  ## errors out of `.cps.` context and taking continuations as input.
-  expectKind(n, nnkProcDef)
-
-  # Create a version of the proc that lacks a first argument or return
-  # value.  While this version will throw an exception at runtime, it
-  # may be used inside CPS as magic(); for better programmer ergonomics.
-  var shim = copyNimTree n
-  del(shim.params, 1)               # delete the 1st Continuation argument
-  let msg = newLit($n.name & "() is only valid in {.cps.} context")
-  shim.body =                       # raise a defect when invoked directly
-    quote:
-      raise Defect.newException: `msg`
-  result = shim
-
-macro cpsMagic*(n: untyped): untyped =
-  ## Applied to a procedure to generate a version which lacks the first
-  ## argument and return value, which are those of a `Continuation`.
-  ##
-  ## This new magical will compile correctly inside CPS procedures though
-  ## it never takes a `Continuation` argument and produces no return value.
-  ##
-  ## The target procedure of a cpsMagic pragma returns the `Continuation`
-  ## to which control-flow should return; this is _usually_ the same value
-  ## passed into the procedure, but this is not required nor is it checked!
-  expectKind(n, nnkProcDef)
-  result = newStmtList n            # preserve the original proc
-  var shim = makeErrorShim n        # create the shim
-  shim.params[0] = newEmptyNode()   # wipe out the return value
-
-  # we use these pragmas to identify the primitive and rewrite it inside
-  # CPS so that it again binds to the version that takes and returns a
-  # continuation.
-  shim.addPragma ident"cpsMustJump"
-  shim.addPragma ident"cpsMagicCall"
-  result.add shim
 
 macro cpsVoodoo*(n: untyped): untyped =
   ## Similar to a `cpsMagic` where the first argument is concerned, but
@@ -218,25 +180,3 @@ template `()`(c: Continuation): untyped {.used.} =
   ## Returns the result, i.e. the return value, of a continuation.
   discard
 {.pop.}
-
-
-proc unwind*(c: Continuation; e: ref Exception): Continuation
-
-proc handler*(c: Continuation;
-              fn: Continuation.fn): Continuation {.used, cpsMagic.} =
-  ## This symbol may be reimplemented to customize exception handling.
-  result =
-    if c.ex.isNil and not c.fn.isNil:
-      fn(c)
-    else:
-      unwind(c, c.ex)
-
-proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
-                                                                cpsMagic.} =
-  ## This symbol may be reimplemented to customize stack unwind.
-  if c.mom.isNil and not e.isNil:
-    raise e
-  else:
-    result = c.mom
-    result.ex = e
-    result = handler(result, result.fn)

--- a/cps/hooks.nim
+++ b/cps/hooks.nim
@@ -79,8 +79,11 @@ proc hook*(hook: Hook; a: NimNode; b: NimNode): NimNode =
     # hook(Cont, env_234234)
     newCall(hook.sym, a, b)
   of Unwind:
-    # hook(continuation, exception)
-    newCall(hook.sym, a, b)
+    # hook(continuation, Cont)
+    let unwind = hook.sym
+    quote:
+      if not `a`.ex.isNil:
+        return `unwind`(`a`, `a`.ex).`b`
   of Pass, Tail:
     # hook(source, destination)
     newCall(hook.sym, a, b)

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -40,6 +40,7 @@ type
     ## If this Continuation was invoked by another Continuation,
     ## the `mom` will hold that parent Continuation to form a
     ## linked-list approximating a stack.
+    ex*: ref Exception
 
   ContinuationProc*[T] = proc(c: T): T {.nimcall.}
 

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -941,10 +941,13 @@ proc handler*(c: Continuation;
               fn: Continuation.fn): Continuation {.used, cpsMagic.} =
   ## This symbol may be reimplemented to customize exception handling.
   result =
-    if c.ex.isNil and not c.fn.isNil:
+    if fn.isNil:
+      unwind(c, c.ex)
+    elif c.ex.isNil:
       fn(c)
     else:
-      unwind(c, c.ex)
+      # we're exploiting expr evaluation order here!
+      unwind(fn(c), c.ex)
 
 proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
                                                                 cpsMagic.} =

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -952,8 +952,11 @@ proc handler*(c: Continuation;
 proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
                                                                 cpsMagic.} =
   ## This symbol may be reimplemented to customize stack unwind.
-  if c.mom.isNil and not e.isNil:
-    raise e
+  if c.mom.isNil:
+    if e.isNil:
+      result = c
+    else:
+      raise e
   else:
     result = c.mom
     result.ex = e

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -20,7 +20,9 @@ proc makeContProc(name, cont, source: NimNode): NimNode =
   result = newProc(name, [contType, newIdentDefs(contParam, contType)])
   result.copyLineInfo source        # grab lineinfo from the source body
   result.body = newStmtList()       # start with an empty body
-  result.introduce {Coop, Pass, Head, Tail, Trace, Alloc, Dealloc}
+  result.introduce {Coop, Pass, Head, Tail, Trace, Alloc, Dealloc, Unwind}
+  result.body.add:                  # perform any possible stack unwind
+    Unwind.hook cont, contType      # before any other activity, then
   result.body.add:                  # insert a hook ahead of the source,
     Trace.hook contParam, result    # hooking against the proc (minus body)
   result.body.add:                  # perform convenience rewrites on source

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -973,7 +973,7 @@ proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
     else:
       result = c.mom
       result.ex = e
-      result = handler(result, result.fn)
+      #result = handler(result, result.fn)
 
 macro cpsHandleUnhandledException(n: typed): untyped =
   ## rewrites all continuations in `n` so that any unhandled exception will

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -988,7 +988,8 @@ macro cpsHandleUnhandledException(n: typed): untyped =
       result.body = genAstOpt({}, cont, body = result.body):
         bind getCurrentException
         try:
-          body
+          if cont.ex.isNil:
+            body
         except:
           cont.ex = getCurrentException()
         # A continuation body created with makeContProc (which is all of them)

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -939,7 +939,7 @@ proc unwind*(c: Continuation; e: ref Exception): Continuation
 
 proc handler*(c: Continuation;
               fn: Continuation.fn): Continuation {.used, cpsMagic.} =
-  ## This symbol may be reimplemented to customize exception handling.
+  ## Reimplement this symbol to customize exception handling.
   result =
     if fn.isNil:
       unwind(c, c.ex)
@@ -951,7 +951,7 @@ proc handler*(c: Continuation;
 
 proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
                                                                 cpsMagic.} =
-  ## This symbol may be reimplemented to customize stack unwind.
+  ## Reimplement this symbol to customize stack unwind.
   if c.mom.isNil:
     if e.isNil:
       result = c

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -978,8 +978,6 @@ proc unwind*(c: Continuation; e: ref Exception): Continuation {.used,
 macro cpsHandleUnhandledException(n: typed): untyped =
   ## rewrites all continuations in `n` so that any unhandled exception will
   ## be first copied into the `ex` variable, then raise
-  ##
-  ## XXX: raising is the temporary behavior until unwind is implemented
   func handle(n: NimNode): NimNode =
     if n.isCpsCont:
       let cont = n.getContSym

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -988,8 +988,7 @@ macro cpsHandleUnhandledException(n: typed): untyped =
       result.body = genAstOpt({}, cont, body = result.body):
         bind getCurrentException
         try:
-          if cont.ex.isNil:
-            body
+          body
         except:
           cont.ex = getCurrentException()
         # A continuation body created with makeContProc (which is all of them)

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -965,6 +965,9 @@ macro cpsHandleUnhandledException(n: typed): untyped =
     if n.isCpsCont:
       let cont = n.getContSym
       result = copy n
+      # Rewrite continuations within this continuation body as well
+      result.body = result.body.filter(handle)
+      # Put the body in a try-except to capture the unhandled exception
       result.body = genAstOpt({}, cont, body = result.body):
         bind getCurrentException
         try:

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -991,7 +991,12 @@ macro cpsHandleUnhandledException(n: typed): untyped =
           body
         except:
           cont.ex = getCurrentException()
-          return (typeof cont) unwind(cont, cont.ex)
+        # A continuation body created with makeContProc (which is all of them)
+        # will have a terminator in the body, thus this part can only be reached
+        # iff the except branch happened to deter the jump
+        #
+        # This is a workaround for https://github.com/nim-lang/Nim/issues/18411
+        return (typeof cont) unwind(cont, cont.ex)
 
   debugAnnotation cpsHandleUnhandledException, n:
     it = it.filter(handle)

--- a/tests/thooks.nim
+++ b/tests/thooks.nim
@@ -49,13 +49,13 @@ suite "hooks":
     let s = found.join("\10")
     const
       expected = """
-        0: foo 4 24
-        1: While Loop 12 24
-        2: Post Call 8 24
-        3: While Loop 12 24
-        4: Post Call 8 24
-        5: While Loop 12 24
-        6: Post Call 8 24
+        0: foo 4 32
+        1: While Loop 12 32
+        2: Post Call 8 32
+        3: While Loop 12 32
+        4: Post Call 8 32
+        5: While Loop 12 32
+        6: Post Call 8 32
       """.dedent(8).strip()
     check "trace output doesn't match":
       s == expected
@@ -194,3 +194,25 @@ suite "hooks":
     check "bzzzt bootstrapped":
       h == t
       t == 1
+
+  block:
+    ## custom continuation exception handling works
+    skip "🚧 watch your step 🚧"
+    var k = newKiller 3
+
+    proc unwind(c: Cont; ex: ref Exception): Continuation {.cpsMagic.} =
+      step 3
+      result = cps.unwind(c, ex)
+
+    proc bar() {.cps: Cont.} =
+      step 2
+      noop()
+      raise IOError.newException "hol' up"
+
+    proc foo() {.cps: Cont.} =
+      step 1
+      bar()
+      step 4
+
+    expect IOError:
+      foo()

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -388,7 +388,6 @@ suite "try statements":
 
   block:
     ## handling exception across multiple continuations
-    skip "not supported yet"
     var k = newKiller(6)
     proc foo() {.cps: Cont.} =
       noop()


### PR DESCRIPTION
Not much to do; we just need to set the `ex` field on the `Continuation` and jump via the `unwind` in the event of an exception.

@alaviss needs to weigh in.