### PR TITLE
Exceptions refactoring and try-finally transform

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -3,8 +3,9 @@ import cps/[spec, transform, rewrites, hooks]
 export Continuation, ContinuationProc
 export cpsCall, cpsMagicCall, cpsVoodooCall, cpsMustJump
 
+# exporting some symbols that we had to bury for bindSym reasons
 from cps/returns import pass
-export pass
+export pass, trampoline
 
 # we only support arc/orc due to its eager expr evaluation qualities
 when not(defined(gcArc) or defined(gcOrc)):
@@ -47,14 +48,6 @@ template dismissed*(c: Continuation): bool =
   (Continuation c).state == Dismissed
 
 {.pop.}
-
-proc trampoline*[T: Continuation](c: T): T =
-  ## This is the basic trampoline: it will run the continuation
-  ## until the continuation is no longer in the `Running` state.
-  var c: Continuation = c
-  while c.running:
-    c = c.fn(c)
-  result = T c
 
 macro trampolineIt*[T: Continuation](supplied: T; body: untyped) =
   ## This trampoline allows the user to interact with the continuation

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -489,11 +489,9 @@ proc createBootstrap*(env: Env; n: ProcDef, goto: NimNode): ProcDef =
     result = desym(result, defs[0])
 
   # now the trampoline
+  let tramp = bindSym"trampoline"
   result.body.add:
-    nnkWhileStmt.newTree: [
-      newCall(ident"running", c),  # XXX: bindSym?  bleh.
-      newAssignment(c, env.castToRoot newDotExpr(c, env.fn).newCall(c))
-    ]
+    newAssignment(c, newCall(tramp, c))
 
   # do an easy static check, and then
   if env.rs.typ != result.returnParam:

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -382,20 +382,18 @@ proc rewriteReturn*(e: var Env; n: NimNode): NimNode =
       result = newStmtList()
       # ignore the result symbol and create a new assignment
       result.add newAssignment(e.get, n.last.last)
-      # and just issue an empty `return`
-      result.add nnkReturnStmt.newNimNode(n).add newEmptyNode()
-    of nnkEmpty, nnkIdent:
-      # this is `return` or `return continuation`, so that's fine...
-      result = n
+      # and add the termination annotation
+      result.add newCpsTerminate()
+    of nnkEmpty:
+      # this is an empty return
+      result = newCpsTerminate()
     else:
       # okay, it's a return of some rando expr
       result = newStmtList()
       # ignore the result symbol and create a new assignment
       result.add newAssignment(e.get, n.last)
-      # signify the end of the continuation
-      result.add newAssignment(newDotExpr(e.first, e.fn), newNilLit())
-      # and return the continuation
-      result.add nnkReturnStmt.newNimNode(n).add(e.first)
+      # and add the termination annotation
+      result.add newCpsTerminate()
 
 proc rewriteSymbolsIntoEnvDotField*(e: var Env; n: NimNode): NimNode =
   ## swap symbols for those in the continuation

--- a/cps/rewrites.nim
+++ b/cps/rewrites.nim
@@ -283,8 +283,8 @@ proc normalizingRewrites*(n: NimNode): NimNode =
       ## We simplify this AST so that our rewrites can capture it.
       case n.kind
       of nnkExceptBranch:
-        # If this except branch has an exception matching clause
-        if n.len > 1:
+        # If this except branch has exactly one exception matching clause
+        if n.len == 2:
           # If the exception matching clause is an infix expression (T as e)
           if n[0].kind == nnkInfix:
             let

--- a/cps/rewrites.nim
+++ b/cps/rewrites.nim
@@ -272,6 +272,40 @@ proc normalizingRewrites*(n: NimNode): NimNode =
       else:
         discard
 
+    proc rewriteExceptBranch(n: NimNode): NimNode =
+      ## Rewrites except branches in the form of `except T as e` into:
+      ##
+      ## ```
+      ## except T:
+      ##   let e = (ref T)(getCurrentException())
+      ## ```
+      ##
+      ## We simplify this AST so that our rewrites can capture it.
+      case n.kind
+      of nnkExceptBranch:
+        # If this except branch has an exception matching clause
+        if n.len > 1:
+          # If the exception matching clause is an infix expression (T as e)
+          if n[0].kind == nnkInfix:
+            let
+              typ = n[0][1] # T in (T as e)
+              refTyp = nnkRefTy.newTree(typ) # make a (ref T) node
+              ex = n[0][2] # our `e`
+              body = n[1]
+
+            result = copyNimNode(n) # copy the `except`
+            result.add typ # add only `typ`
+            result.add:
+              newStmtList:
+                # let ex: ref T = (ref T)(getCurrentException())
+                nnkLetSection.newTree:
+                  newIdentDefs(ex, refTyp, newCall(refTyp, newCall(bindSym"getCurrentException")))
+
+            # add the rewritten body
+            result.last.add:
+              normalizingRewrites body
+      else: discard
+
     case n.kind
     of nnkIdentDefs:
       rewriteIdentDefs n
@@ -287,6 +321,8 @@ proc normalizingRewrites*(n: NimNode): NimNode =
       rewriteFormalParams n
     of CallNodes, nnkHiddenSubConv, nnkHiddenStdConv:
       rewriteHidden n
+    of nnkExceptBranch:
+      rewriteExceptBranch n
     else:
       nil
 

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -218,3 +218,11 @@ proc isVoodooCall*(n: NimNode): bool =
       let callee = n[0]
       if not callee.isNil and callee.kind == nnkSym:
         result = callee.getImpl.hasPragma "cpsVoodooCall"
+
+proc trampoline*[T: Continuation](c: T): T =
+  ## This is the basic trampoline: it will run the continuation
+  ## until the continuation is no longer in the `Running` state.
+  var c: Continuation = c
+  while not c.isNil and not c.fn.isNil:
+    c = c.fn(c)
+  result = T c

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -99,8 +99,9 @@ proc stripPragma*(n: NimNode; s: static[string]): NimNode =
     result = n
 
 proc hash*(n: NimNode): Hash =
+  ## Hash a NimNode via it's representation
   var h: Hash = 0
-  h = h !& hash($n)
+  h = h !& hash(repr n)
   result = !$h
 
 func newCpsPending*(): NimNode =

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -25,6 +25,7 @@ template cpsContinue*() {.pragma.}      ##
 template cpsCont*() {.pragma.}          ## this is a continuation
 template cpsBootstrap*(whelp: typed) {.pragma.}  ##
 ## the symbol for creating a continuation
+template cpsTerminate*() {.pragma.}     ## this is the end of this procedure
 
 type
   Continuation* = ref object of RootObj
@@ -161,11 +162,18 @@ proc getContSym*(n: NimNode): NimNode =
   else:
     nil
 
+proc newCpsTerminate*(): NimNode =
+  ## Create a new node signifying early termination of the procedure
+  nnkPragma.newTree:
+    bindSym"cpsTerminate"
+
+proc isCpsTerminate*(n: NimNode): bool =
+  ## Return whether `n` is a cpsTerminate annotation
+  n.kind == nnkPragma and n.len == 1 and n.hasPragma("cpsTerminate")
+
 proc isScopeExit*(n: NimNode): bool =
-  ## Return whether the given node signify a scope exit
-  ##
-  ## TODO: Handle early exit (ie. `c.fn = nil; return`)
-  n.isCpsPending or n.isCpsBreak or n.isCpsContinue
+  ## Return whether the given node signify a CPS scope exit
+  n.isCpsPending or n.isCpsBreak or n.isCpsContinue or n.isCpsTerminate
 
 template rewriteIt*(n: typed; body: untyped): NimNode =
   var it {.inject.} = normalizingRewrites:

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -137,18 +137,6 @@ proc isCpsContinue*(n: NimNode): bool =
   ## Return whether a node is a {.cpsContinue.} annotation
   n.kind == nnkPragma and n.len == 1 and n.hasPragma("cpsContinue")
 
-when defined(cpsRecover):
-  template cpsRecover() {.pragma.}   ## the next step in finally recovery path
-
-  func newCpsRecover(n: NimNode): NimNode =
-    ## Produce a {.cpsRecover.} annotation
-    nnkPragma.newNimNode(n).add:
-      bindSym"cpsRecover"
-
-  func isCpsRecover(n: NimNode): bool =
-    ## Return whether a node is a {.cpsRecover.} annotation
-    n.kind == nnkPragma and n.len == 1 and n.hasPragma("cpsRecover")
-
 proc breakLabel*(n: NimNode): NimNode =
   ## Return the break label of a `break` statement or a `cpsBreak` annotation
   if n.isCpsBreak():

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -188,16 +188,8 @@ proc rewriteExcept(cont, ex, n: NimNode): tuple[cont, excpt: NimNode] =
   var body = newStmtList(n.last)
   # this is `except Type: body`
   if n.len > 1:
-    # this is `except Type as e: body`
-    if n[0].kind == nnkInfix:
-      # replace all occurance of `e` with `ex`
-      body = body.resym(n[0][2], ex)
-
-      # add `Type` to our new except clause
-      result.excpt.add n[0][1]
-    else:
-      # add `Type`
-      result.excpt.add n[0]
+    # add `Type`
+    result.excpt.add n[0]
 
   proc setException(contSym, n: NimNode): NimNode =
     ## Set the exception to `ex` before running any other code

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -212,8 +212,7 @@ proc rewriteExcept(cont, ex, n: NimNode): tuple[cont, excpt: NimNode] =
     result = newStmtList():
       newCall(bindSym"setCurrentException", ex.resym(cont, contSym))
 
-    for i in n.items:
-      result.add i.filter(setContException)
+    result.add n.filter(setContException)
 
     proc consumeException(n: NimNode): NimNode =
       ## Prepend all cpsPending with `setCurrentException nil`

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -443,8 +443,7 @@ macro cpsTryFinally(cont, ex, n: typed): untyped =
       ## Given a continuation template `templ`, replace all `replace` with
       ## `replacement`, then generate a new set of symbols for all
       ## continuations within.
-      # The key is the symbol need updating and the value is what to update
-      # it to
+      # A simple mapping of node and what to replace it with
       var replacements: Table[NimNode, NimNode]
       proc generator(n: NimNode): NimNode =
         # If it's a continuation
@@ -466,7 +465,7 @@ macro cpsTryFinally(cont, ex, n: typed): untyped =
           result = copyNimTree(replacements[n])
 
       replacements[replace] = replacement
-      templ.filter(generator)
+      result = filter(templ, generator)
 
     # Create a symbol to use as the placeholder for the finally leg next jump.
     let nextJump = nskUnknown.genSym"nextJump"

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -455,7 +455,7 @@ proc annotate(parent: var Env; n: NimNode): NimNode =
         var jumpCall: NimNode
         if final.isNil:                    # no finally!
           jumpCall = env.newAnnotation(nc, "cpsTryExcept")
-          jumpCall.add env.getException()  # exception access
+          jumpCall.add env.genException()  # exception access
           jumpCall.add:
             newStmtList env.annotate(nc)   # try body
         else:
@@ -465,7 +465,7 @@ proc annotate(parent: var Env; n: NimNode): NimNode =
             else:
               wrappedFinally(nc, final)    # try/try-except/finally
           jumpCall = env.newAnnotation(nc, "cpsTryFinally")
-          jumpCall.add env.getException()  # exception access
+          jumpCall.add env.genException()  # exception access
           jumpCall.add:
             newStmtList env.annotate(body) # try body
         result.add jumpCall

--- a/tests/preamble.nim
+++ b/tests/preamble.nim
@@ -17,7 +17,7 @@ proc trampoline[T: Continuation](c: T) =
     setCurrentException(nil)
     c = c.fn(c)
     # no exception should leak outside of the continuation
-    check getCurrentException().isNil
+    check getCurrentException().isNil, "exception leaked from the continuation"
     inc jumps
     if jumps > 1000:
       raise InfiniteLoop.newException: $jumps & " iterations"

--- a/tests/tdefer.nim
+++ b/tests/tdefer.nim
@@ -9,21 +9,18 @@ suite "defer statements":
 
   block:
     ## a defer statement works across a continuation
-    when true:
-      skip "not working, see #80"
-    else:
-      r = 0
-      proc foo() {.cps: Cont.} =
-        defer:
-          check r == 2, "defer run before end of scope"
-          inc r
-
-        inc r
-        noop()
+    r = 0
+    proc foo() {.cps: Cont.} =
+      defer:
+        check r == 2, "defer run before end of scope"
         inc r
 
-      foo()
-      check r == 3
+      inc r
+      noop()
+      inc r
+
+    foo()
+    check r == 3
 
   block:
     ## a basic defer statement is supported

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -95,20 +95,22 @@ suite "try statements":
 
   block:
     ## try statements with a finally and a return
-    skip"pending https://github.com/nim-lang/Nim/issues/18254":
-      r = 0
+    r = 0
 
-      proc foo() {.cps: Cont.} =
+    proc foo() {.cps: Cont.} =
+      inc r
+      try:
+        noop()
         inc r
-        try:
-          noop()
-          inc r
-          return
-        finally:
-          inc r
+        return
+        fail"statement run after return"
+      finally:
+        inc r
 
-      trampoline whelp(foo())
-      check r == 3
+      fail"statement run after try-finally containing a return"
+
+    trampoline whelp(foo())
+    check r == 3
 
   block:
     ## try statements with an exception and a finally

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -81,7 +81,7 @@ suite "try statements":
 
   block:
     ## try statements with a finally clause
-    skip "not working, see #78":
+    skip"pending https://github.com/nim-lang/Nim/issues/18254":
       r = 0
       proc foo() {.cps: Cont.} =
         inc r
@@ -96,8 +96,9 @@ suite "try statements":
 
   block:
     ## try statements with a finally and a return
-    skip "not working, see #78":
+    skip"pending https://github.com/nim-lang/Nim/issues/18254":
       r = 0
+
       proc foo() {.cps: Cont.} =
         inc r
         try:
@@ -112,7 +113,7 @@ suite "try statements":
 
   block:
     ## try statements with an exception and a finally
-    skip "not working, see #78":
+    skip"pending https://github.com/nim-lang/Nim/issues/18254":
       r = 0
       proc foo() {.cps: Cont.} =
         inc r
@@ -129,6 +130,25 @@ suite "try statements":
 
       trampoline whelp(foo())
       check r == 5
+
+  block:
+    ## try statements with a split in finally
+    skip"pending https://github.com/nim-lang/Nim/issues/18254":
+      r = 0
+      proc foo() {.cps: Cont.} =
+        inc r
+
+        try:
+          noop()
+          inc r
+        finally:
+          noop()
+          inc r
+
+        inc r
+
+      trampoline whelp(foo())
+      check r == 4
 
   block:
     ## nested try statements within the except branch

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -130,3 +130,33 @@ suite "try statements":
       foo()
       check r == 5
 
+  block:
+    ## nested try statements within the except branch
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      try:
+        noop()
+        inc r
+        raise newException(CatchableError, "test")
+        fail "statement run after raise"
+      except:
+        check getCurrentExceptionMsg() == "test"
+        inc r
+
+        try:
+          noop()
+          inc r
+          raise newException(CatchableError, "test 2")
+          fail "statement run after raise"
+        except:
+          check getCurrentExceptionMsg() == "test 2"
+          inc r
+
+        check getCurrentExceptionMsg() == "test"
+        inc r
+
+      inc r
+
+    foo()
+    check r == 7

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -19,7 +19,7 @@ suite "try statements":
         fail "this branch should not run"
       inc r
 
-    foo()
+    trampoline whelp(foo())
     check r == 3
 
   block:
@@ -37,7 +37,7 @@ suite "try statements":
         inc r
       inc r
 
-    foo()
+    trampoline whelp(foo())
     check r == 4
 
   block:
@@ -57,7 +57,7 @@ suite "try statements":
         inc r
       inc r
 
-    foo()
+    trampoline whelp(foo())
     check r == 5
 
   block:
@@ -76,7 +76,7 @@ suite "try statements":
         inc r
       inc r
 
-    foo()
+    trampoline whelp(foo())
     check r == 5
 
   block:
@@ -91,7 +91,7 @@ suite "try statements":
         finally:
           inc r
 
-      foo()
+      trampoline whelp(foo())
       check r == 3
 
   block:
@@ -107,7 +107,7 @@ suite "try statements":
         finally:
           inc r
 
-      foo()
+      trampoline whelp(foo())
       check r == 3
 
   block:
@@ -127,7 +127,7 @@ suite "try statements":
           inc r
         inc r
 
-      foo()
+      trampoline whelp(foo())
       check r == 5
 
   block:
@@ -158,5 +158,5 @@ suite "try statements":
 
       inc r
 
-    foo()
+    trampoline whelp(foo())
     check r == 7

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -81,18 +81,17 @@ suite "try statements":
 
   block:
     ## try statements with a finally clause
-    skip"pending https://github.com/nim-lang/Nim/issues/18254":
-      r = 0
-      proc foo() {.cps: Cont.} =
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      try:
+        noop()
         inc r
-        try:
-          noop()
-          inc r
-        finally:
-          inc r
+      finally:
+        inc r
 
-      trampoline whelp(foo())
-      check r == 3
+    trampoline whelp(foo())
+    check r == 3
 
   block:
     ## try statements with a finally and a return
@@ -113,42 +112,61 @@ suite "try statements":
 
   block:
     ## try statements with an exception and a finally
-    skip"pending https://github.com/nim-lang/Nim/issues/18254":
-      r = 0
-      proc foo() {.cps: Cont.} =
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+      try:
+        noop()
         inc r
-        try:
-          noop()
-          inc r
-          raise newException(CatchableError, "")
-          fail "statement run after raise"
-        except:
-          inc r
-        finally:
-          inc r
+        raise newException(CatchableError, "")
+        fail "statement run after raise"
+      except:
         inc r
+      finally:
+        inc r
+      inc r
 
-      trampoline whelp(foo())
-      check r == 5
+    trampoline whelp(foo())
+    check r == 5
 
   block:
     ## try statements with a split in finally
-    skip"pending https://github.com/nim-lang/Nim/issues/18254":
-      r = 0
-      proc foo() {.cps: Cont.} =
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+
+      try:
+        noop()
+        inc r
+      finally:
+        noop()
         inc r
 
-        try:
-          noop()
-          inc r
-        finally:
-          noop()
-          inc r
+      inc r
 
+    trampoline whelp(foo())
+    check r == 4
+
+  block:
+    ## try statements with a split in finally with an unhandled exception
+    r = 0
+    proc foo() {.cps: Cont.} =
+      inc r
+
+      try:
+        noop()
+        inc r
+        raise newException(ValueError, "test")
+        fail"code run after raise"
+      finally:
+        noop()
         inc r
 
+      fail"code run after raising try-finally"
+
+    expect ValueError:
       trampoline whelp(foo())
-      check r == 4
+    check r == 3
 
   block:
     ## nested try statements within the except branch

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -80,6 +80,43 @@ suite "try statements":
     check r == 5
 
   block:
+    ## except statement catching multiple exception types across splits
+    proc foo() {.cps: Cont.} =
+      inc r
+      try:
+        noop()
+        inc r
+        raise newException(ValueError, "test")
+        fail "statement run after raise"
+      except ValueError, IOError:
+        check getCurrentExceptionMsg() == "test"
+        inc r
+
+      inc r
+
+    proc bar() {.cps: Cont.} =
+      # Same as foo(), but with the constraints switched
+      inc r
+      try:
+        noop()
+        inc r
+        raise newException(ValueError, "test")
+        fail "statement run after raise"
+      except IOError, ValueError:
+        check getCurrentExceptionMsg() == "test"
+        inc r
+
+      inc r
+
+    r = 0
+    trampoline whelp(foo())
+    check r == 4
+
+    r = 0
+    trampoline whelp(bar())
+    check r == 4
+
+  block:
     ## try statements with a finally clause
     r = 0
     proc foo() {.cps: Cont.} =

--- a/tests/tzevv.nim
+++ b/tests/tzevv.nim
@@ -214,14 +214,11 @@ suite "suite, suite zevv":
       prim()
 
   test "defer":
-    when true:
-      skip "pending try-finally rewrite"
-    else:
-      expPrims 3: runCps:
+    expPrims 3: runCps:
+      prim()
+      defer:
         prim()
-        defer:
-          prim()
-        prim()
+      prim()
 
   test "nested while":
     expPrims 100: runCps:


### PR DESCRIPTION
As usual, the compiler blocks our transform: ~~https://github.com/nim-lang/Nim/issues/18254~~ Worked around that bug

Blocked by: https://github.com/nim-lang/Nim/pull/18247

So main changes:
- Moved a few things around
- `try-except` is now implemented by merging all `except` branches into one then turn that into a continuation. This should help with implementing an unwinding system for cps.
- `try-finally` is implemented by turning the `finally` leg into a continuation ~~taking a generic parameter pointing to where to go next.~~ then specialize it to each exit legs.

Known issues:
- ~~`try-except` doesn't work with except branches matching multiple exception types: `except ValueError, IOError`.~~
- ~~`try-finally` doesn't handle early returns, but this is fixable by improving `isScopeExit` and making early return an annotation.~~