### PR TITLE
cps/transform: implement a context management system for exception

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -26,6 +26,7 @@ template cpsCont*() {.pragma.}          ## this is a continuation
 template cpsBootstrap*(whelp: typed) {.pragma.}  ##
 ## the symbol for creating a continuation
 template cpsTerminate*() {.pragma.}     ## this is the end of this procedure
+template cpsHasException*() {.pragma.}  ## the continuation is exception-managed
 
 type
   Continuation* = ref object of RootObj

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -26,7 +26,9 @@ template cpsCont*() {.pragma.}          ## this is a continuation
 template cpsBootstrap*(whelp: typed) {.pragma.}  ##
 ## the symbol for creating a continuation
 template cpsTerminate*() {.pragma.}     ## this is the end of this procedure
-template cpsHasException*() {.pragma.}  ## the continuation is exception-managed
+template cpsHasException*(cont, ex: typed) {.pragma.}  ##
+## the continuation has an exception stored in `ex`, with `cont` being the
+## continuation symbol used.
 
 type
   Continuation* = ref object of RootObj

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -404,8 +404,9 @@ macro cpsTryExcept(cont, ex, n: typed): untyped =
 
   # write a try-except clause to wrap on all children continuations so that
   # they jump to the handler upon an exception
-  let placeholder = genSym(nskUnknown, "placeholder")
-  let tryTemplate = copyNimNode n
+  let
+    placeholder = genSym(nskUnknown, "placeholder")
+    tryTemplate = copyNimNode n
 
   # add the placeholder as the body
   tryTemplate.add placeholder

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -442,6 +442,8 @@ macro cpsTryFinally(cont, ex, n: typed): untyped =
     # use a fresh StmtList as our result
     it = newStmtList()
 
+    # The previous pass should give us a try-finally block, thus the last
+    # child is our finally, and the last child of finally is its body.
     let finallyBody = tryFinally.last.last
 
     # Turn the finally into a continuation leg.

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -291,7 +291,7 @@ proc mergeExceptBranches(n, ex: NimNode): NimNode =
         newStmtList:
           ifStmt
 
-proc wrapContinuationWith(n, cont, replace, templ: NimNode): NimNode =
+func wrapContinuationWith(n, cont, replace, templ: NimNode): NimNode =
   ## Given the StmtList `n`, return `templ` with children matching `replace`
   ## replaced with the `n`.
   ##
@@ -301,7 +301,7 @@ proc wrapContinuationWith(n, cont, replace, templ: NimNode): NimNode =
   proc wrapCont(n: NimNode): NimNode =
     ## Wrap the body of continuation `n` with the template
     if n.isCpsCont:
-      result = n
+      result = copyNimTree n
       let nextCont = n.getContSym
       result.body = result.body.wrapContinuationWith(nextCont, replace):
         if cont.kind == nnkSym:
@@ -316,7 +316,7 @@ proc wrapContinuationWith(n, cont, replace, templ: NimNode): NimNode =
       # wrap all continuations of `n` with the template
       filter(n, wrapCont)
 
-proc withException(n, cont, ex: NimNode): NimNode =
+func withException(n, cont, ex: NimNode): NimNode =
   ## Given the exception handler continuation `n`, set the global exception of
   ## continuation `cont` in the scope of `n` to `ex` before any code is run.
   ##
@@ -334,7 +334,7 @@ proc withException(n, cont, ex: NimNode): NimNode =
 
     # If n is a continuation
     elif n.isCpsCont:
-      result = n
+      result = copyNimTree n
 
       let
         nextCont = result.getContSym()
@@ -447,7 +447,7 @@ macro cpsTryFinally(cont, ex, n: typed): untyped =
     let finallyBody = tryFinally.last.last
 
     # Turn the finally into a continuation leg.
-    var final = makeContProc(nskProc.genSym("Finally"), cont, finallyBody)
+    let final = makeContProc(nskProc.genSym("Finally"), cont, finallyBody)
 
     # A property of `finally` is that it inserts itself in the middle
     # of any scope exit attempt before performing the scope exit.

--- a/tests/preamble.nim
+++ b/tests/preamble.nim
@@ -13,11 +13,11 @@ proc trampoline[T: Continuation](c: T) =
   jumps = 0
   var c = Continuation c
   while c.running:
-    # pretends that an exception is raised and handled elsewhere
-    setCurrentException(nil)
+    # capture the exception in the environment
+    let exception = getCurrentException()
     c = c.fn(c)
-    # no exception should leak outside of the continuation
-    check getCurrentException().isNil, "exception leaked from the continuation"
+    # the current exception should not change
+    check getCurrentException() == exception
     inc jumps
     if jumps > 1000:
       raise InfiniteLoop.newException: $jumps & " iterations"

--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -264,6 +264,55 @@ suite "try statements":
       check getCurrentExceptionMsg() == "outside cps test"
 
   block:
+    ## running a continuation that handles exception then raises while handling
+    ## an exception in the exception handler
+    r = 0
+
+    # This is a very delicate test designed to demonstrate an issue with
+    # Nim's exception stack mechanism and CPS
+
+    proc foo() {.cps: Cont.} =
+      inc r
+
+      try:
+        noop()
+        inc r
+        raise newException(CatchableError, "test")
+      except CatchableError:
+        noop()
+        inc r
+        check getCurrentExceptionMsg() == "test"
+        raise
+
+      fail"this statement cannot be run"
+
+    var c = whelp(foo())
+    # Run two iterations, which should place us right after the raise
+    #
+    # At this point, the parent of our `raise` is `nil`, because there wasn't
+    # any exception being handled at the point of raise.
+    for _ in 1 .. 2:
+      c = Cont c.fn(c)
+
+    try:
+      raise newException(CatchableError, "outside cps test")
+    except CatchableError:
+      # Now we handle an exception, which the current exception is now
+      # "outside cps test"
+      try:
+        # Run the tramp to finish `c`, which will end in a re-raise.
+        trampoline c
+        fail"continuing `c` should raise"
+      except CatchableError:
+        check r == 3
+        # Confirm that this is the exception from cps
+        check getCurrentExceptionMsg() == "test"
+
+      # Confirm that the stack has been fixed and the parent of the inner
+      # exception is the outer.
+      check getCurrentExceptionMsg() == "outside cps test"
+
+  block:
     ## calling a continuation with finally while handling an exception
     r = 0
     proc foo() {.cps: Cont.} =


### PR DESCRIPTION
Exception handlers in Nim operates on a stack built within the Exception
object. Thus to ensure that continuations don't corrupt the stack
outside of CPS, we generates a manager that configures the current exception
to the continuation's before running the continuation, then restore the
original on return.

In the case of unhandled exceptions, we restore the old exception stack then
raise the unhandled exception to reconnect them.

Known issue:
- ~~Clearing the exception in the continuation is not reimplemented yet~~
- ~~We are still ignoring unhandled exceptions coming from the continuation~~