### PR TITLE
cps/transform: correctly transform try statement with one cps jump

### DIFF
--- a/tests/ttry.nim
+++ b/tests/ttry.nim
@@ -365,3 +365,22 @@ suite "try statements":
 
     foo()
     check r == 3
+
+  block:
+    ## try statement with one cps jump as the body
+    r = 0
+
+    proc noop(c: Cont): Cont {.cpsMagic.} =
+      inc r
+      result = c
+
+    proc foo() {.cps: Cont.} =
+      try:
+        noop()
+      except:
+        fail"this except branch should not run"
+
+      inc r
+
+    trampoline whelp(foo())
+    check r == 2


### PR DESCRIPTION
The try statement AST have the first child as the body, which can be
inlined by the compiler when there are only one statement within.

In cpsCall handling we assume that control flow continues with the
following nodes, but that is not the case for try statements since the
nodes following the cpsCall are separated execution branches.

We fix this by building putting the cpsCall inside a statement list so
it is separated from the other execution branches.

Fixes #177.