### PR TITLE
cps: implements a pass for flattening expression

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -73,7 +73,7 @@ macro cps*(T: typed, n: typed): untyped =
       # Typically we would add these as pragmas, however it appears
       # that the compiler will run through macros in proc pragmas
       # one-by-one without re-seming the body in between...
-      {.warning: "compiler bug workaround".}
+      {.warning: "compiler bug workaround, see: https://github.com/nim-lang/Nim/issues/18349".}
       result =
         # Add the main transform phase
         newCall(bindSym"cpsTransform", T):

--- a/cps.nim
+++ b/cps.nim
@@ -1,5 +1,5 @@
 import std/[macros]
-import cps/[spec, transform, rewrites, hooks]
+import cps/[spec, transform, rewrites, hooks, exprs]
 export Continuation, ContinuationProc
 export cpsCall, cpsMagicCall, cpsVoodooCall, cpsMustJump
 
@@ -68,7 +68,20 @@ macro cps*(T: typed, n: typed): untyped =
   when defined(nimdoc):
     n
   else:
-    cpsTransformProc(T, n)
+    case n.kind
+    of nnkProcDef:
+      # Typically we would add these as pragmas, however it appears
+      # that the compiler will run through macros in proc pragmas
+      # one-by-one without re-seming the body in between...
+      {.warning: "compiler bug workaround".}
+      result =
+        # Add the main transform phase
+        newCall(bindSym"cpsTransform", T):
+          # Add the flattening phase which will be run first
+          newCall(bindSym"cpsFlattenExpr"):
+            n
+    else:
+      result = getAst(cpsTransform(T, n))
 
 proc makeErrorShim(n: NimNode): NimNode =
   ## Upgrades a procedure to serve as a CPS primitive, generating

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -29,7 +29,7 @@ func hasCpsExpr(n: NormalizedNimNode): bool =
     of nnkStmtList, nnkStmtListExpr:
       for child in n.items:
         if child.NormalizedNimNode.hasCpsExpr:
-          return
+          return true
     else:
       result = false
   else:

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -1,0 +1,182 @@
+import std/macros
+import cps/[spec, normalizedast, help, rewrites]
+
+template cpsMustLift() {.pragma.} ## signify a code block that has to be lifted
+
+proc newCpsMustLift(n: NormalizedNimNode): NormalizedNimNode =
+  ## Wrap `n` in a `cpsMustLift` block.
+  NormalizedNimNode:
+    nnkPragmaBlock.newTree(
+      nnkPragma.newTree(bindSym"cpsMustLift"),
+      n
+    )
+
+proc isCpsMustLift(n: NimNode): bool =
+  ## Check whether `n` is a cpsMustLift block
+  n.kind == nnkPragmaBlock and n[0].len == 1 and n[0].hasPragma("cpsMustLift")
+
+func hasCpsExpr(n: NormalizedNimNode): bool =
+  ## Returns whether `n` has a cps block acting as an expression within it
+  ## (ie. the block has a type) and that these expression might need to be
+  ## moved outside of `n` for the purpose of transformation.
+  # If this node doesn't have a type
+  if n.typeKind == ntyNone:
+    # Check if its children have any
+    case n.kind
+    of nnkVarSection, nnkLetSection:
+      let n = expectVarLet n
+      result = n.val.NormalizedNimNode.hasCpsExpr
+    of nnkStmtList, nnkStmtListExpr:
+      for child in n.items:
+        if child.NormalizedNimNode.hasCpsExpr:
+          return
+    else:
+      result = false
+  else:
+    # Otherwise check if its a cps block
+    result = n.isCpsBlock
+
+func assignTo*(sym: NimNode, n: NormalizedNimNode): NormalizedNimNode =
+  ## Rewrite the expression `n` into a statement assigning to symbol `sym`.
+  ##
+  ## Returns a copy of `n` if `n` is not an expression.
+  if n.typeKind == ntyNone:
+    return NormalizedNimNode:
+      copy n
+
+  case n.kind
+  of AtomicNodes, CallNodes, nnkTupleConstr, nnkObjConstr, nnkConv:
+    # For calls, conversions, constructions, constants and basic symbols, we
+    # just emit the assignment.
+    result = NormalizedNimNode newAssignment(sym, copy n)
+  of nnkStmtList, nnkStmtListExpr:
+    result = NormalizedNimNode copyNimNode n
+
+    # In a statement list, the last node is the expression, so we copy
+    # the part before it because we won't touch them.
+    for idx in 0 ..< n.len - 1:
+      result.add copy(n[idx])
+
+    # Rewrite the last expression to assign to sym.
+    # XXX: discard added because `add()` returns a NimNode.
+    discard result.add:
+      # Convert back to NimNode explicitly because the compiler
+      # can't handle our awesome nodes (our node binds to both
+      # varargs and normal form of add).
+      {.warning: "Compiler workaround here".}
+      NimNode:
+        assignTo(sym):
+          n.last.NormalizedNimNode
+  else:
+    result = NormalizedNimNode:
+      n.errorAst "cps doesn't know how to rewrite this into assignment"
+
+macro cpsExprToTmp(T, n: typed): untyped =
+  ## Create a temporary variable with type `T` and rewrite `n` so that the
+  ## result is assigned to the temporary, then emit the temporary as the
+  ## expression.
+  ##
+  ## Puts the rewritten `n` into cpsMustLift so that it will be moved outside.
+  debugAnnotation cpsExprToTmp, n:
+    let
+      # The symbol for our temporary
+      tmp = genSym(nskVar)
+
+      # The rewritten expression
+      body = assignTo(tmp):
+        # debugAnnotation puts the expr inside a StmtList, so we have to take
+        # it out
+        NormalizedNimNode it[0]
+
+    it =
+      newStmtList(
+        # Mark this part for lifting
+        newCpsMustLift(
+          # Create a new statement list
+          NormalizedNimNode newStmtList(
+            # Declare the temporary
+            newVarSection(tmp, T),
+            # Add the rewritten expression
+            body
+          )
+        ),
+        # Then emit our temporary as the new expression
+        tmp
+      )
+
+macro cpsExprLifter(n: typed): untyped =
+  ## Move cpsMustLift blocks from `n` to before `n`.
+  ## Does not create a new scope.
+
+  proc lift(n: NimNode): NimNode =
+    var lifted = newStmtList()
+    proc lifter(n: NimNode): NimNode =
+      if n.isCpsMustLift:
+        lifted.add:
+          # Lift the bodies inside `n` then add it to the list of lifted bodies
+          lift n.last # The body to be lifted is the last child
+        # Replace `n` with an empty node
+        result = newEmptyNode()
+
+    result = newStmtList(lifted):
+      filter(n, lifter)
+
+  debugAnnotation cpsExprLifter, n:
+    it = lift it
+
+func annotate(n: NormalizedNimNode): NormalizedNimNode =
+  ## Annotate expressions requiring flattening in `n`.
+  result = NormalizedNimNode copyNimNode(n)
+
+  for idx, child in n.pairs:
+    let child = NormalizedNimNode child
+    if child.hasCpsExpr:
+      case child.kind
+      of nnkVarSection, nnkLetSection:
+        let child = expectVarLet(child)
+
+        result.add:
+          # Puts the section under expression lifter in case its value contains
+          # expression that requires lifting.
+          newCall(bindSym"cpsExprLifter"):
+            newStmtList:
+              NimNode:
+                # Clone the VarLet and replace its value.
+                child.clone:
+                  # In the case where the value is a cps call, we don't have to
+                  # move it outside as later CPS pass can rewrite this.
+                  if child.val.isCpsCall:
+                    annotate:
+                      NormalizedNimNode child.val
+                  else:
+                    # Otherwise we transform the expression into a symbol.
+                    NormalizedNimNode:
+                      # TODO: normalizedast should know to run infer
+                      #       automatically on nnkVarTuple because that type
+                      #       doesn't have a type specifier
+                      newCall(bindSym"cpsExprToTmp", copy(child.def.inferTypFromImpl)):
+                        newStmtList:
+                          annotate:
+                            NormalizedNimNode child.val
+
+      else:
+        # Not the type of nodes that needs flattening, rewrites its child
+        # and move on.
+        result.add:
+          NimNode annotate(child)
+    else:
+      # Nothing interesting here, continue.
+      result.add:
+        NimNode annotate(child)
+
+macro cpsFlattenExpr*(n: typed): untyped =
+  ## Flatten any CPS expression in procedure `n` so that control flow involving
+  ## them is linear.
+  expectKind n, nnkProcDef
+  debugAnnotation cpsFlattenExpr, n:
+    # debugAnnotation puts the rewritten `n` inside a StmtList, so we take it
+    # out.
+    it = it[0]
+
+    # Annotate the proc body
+    it.body = annotate(NormalizedNimNode it.body)

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -100,7 +100,7 @@ func filterExpr(n: NormalizedNimNode,
       # Convert back to NimNode explicitly because the compiler
       # can't handle our awesome nodes (our node binds to both
       # varargs and normal form of add).
-      {.warning: "Compiler workaround here".}
+      {.warning: "compiler workaround here, see: https://github.com/nim-lang/Nim/issues/18350".}
       NimNode:
         filterExpr(NormalizedNimNode(n.last), transformer)
   of nnkBlockStmt, nnkBlockExpr:
@@ -115,7 +115,7 @@ func filterExpr(n: NormalizedNimNode,
     # It appears that the type of the `if` expression remains if we
     # don't destroy it by creating a new node instead of copying and
     # causes all sort of errors.
-    {.warning: "compiler workaround here".}
+    {.warning: "compiler workaround here, see: https://github.com/nim-lang/Nim/issues/18351".}
     result = NormalizedNimNode newNimNode(n.kind, n)
 
     for branch in n.items:
@@ -127,7 +127,7 @@ func filterExpr(n: NormalizedNimNode,
     # It appears that the type of the `case` expression remains if we
     # don't destroy it by creating a new node instead of copying and
     # causes all sort of errors.
-    {.warning: "compiler workaround here".}
+    {.warning: "compiler workaround here, see: https://github.com/nim-lang/Nim/issues/18351".}
     result = NormalizedNimNode newNimNode(n.kind, n)
 
     # Copy the matched expression
@@ -339,7 +339,7 @@ macro cpsAsgn(dst, src: typed): untyped =
 macro cpsExprConv(T, n: typed): untyped =
   ## Apply the conversion to `T` directly into `n`'s trailling expressions.
   # If we don't shadow this parameter, it will be nnkNilLit.
-  {.warning: "compiler workaround here".}
+  {.warning: "compiler workaround here, see: https://github.com/nim-lang/Nim/issues/18352".}
   let T = normalizingRewrites T
   debugAnnotation cpsExprConv, n:
     proc addConv(n: NormalizedNimNode): NormalizedNimNode =

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -67,6 +67,15 @@ func assignTo*(sym: NimNode, n: NormalizedNimNode): NormalizedNimNode =
       NimNode:
         assignTo(sym):
           n.last.NormalizedNimNode
+  of nnkBlockStmt, nnkBlockExpr:
+    result = NormalizedNimNode copyNimNode(n)
+    # Copy the label
+    result.add copy(n[0])
+    # Rewrite and add the body
+    result.add:
+      NimNode:
+        assignTo(sym):
+          NormalizedNimNode n[1]
   else:
     result = NormalizedNimNode:
       n.errorAst "cps doesn't know how to rewrite this into assignment"

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -93,8 +93,7 @@ func assignTo*(sym: NimNode, n: NormalizedNimNode): NormalizedNimNode =
       result.add copy(n[idx])
 
     # Rewrite the last expression to assign to sym.
-    # XXX: discard added because `add()` returns a NimNode.
-    discard result.add:
+    result.add:
       # Convert back to NimNode explicitly because the compiler
       # can't handle our awesome nodes (our node binds to both
       # varargs and normal form of add).

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -321,11 +321,14 @@ macro cpsAsgn(dst, src: typed): untyped =
 
 macro cpsExprConv(T, n: typed): untyped =
   ## Apply the conversion to `T` directly into `n`'s trailling expressions.
+  # If we don't shadow this parameter, it will be nnkNilLit.
+  {.warning: "compiler workaround here".}
+  let T = normalizingRewrites T
   debugAnnotation cpsExprConv, n:
     proc addConv(n: NormalizedNimNode): NormalizedNimNode =
       NormalizedNimNode newCall(T, copy n)
 
-    it = filterExpr(NormalizedNimNode(it), addConv)
+    it = filterExpr(NormalizedNimNode(it[0]), addConv)
 
 macro cpsExprLifter(n: typed): untyped =
   ## Move cpsMustLift blocks from `n` to before `n`.

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -198,11 +198,7 @@ func isMutable(n: NormalizedNimNode): bool =
   ## changes in the program state.
   case n.kind
   of nnkSym:
-    result = n.symKind notin {
-      nskGenericParam, nskParam, nskModule, nskType, nskLet, nskConst, nskProc,
-      nskFunc, nskMethod, nskIterator, nskConverter, nskMacro, nskTemplate,
-      nskEnumField, nskField, nskLabel
-    }
+    result = n.symKind in {nskVar, nskResult}
   of AtomicNodes - {nnkSym}:
     result = false
   of nnkAddr, nnkHiddenAddr:

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -83,7 +83,7 @@ func filterExpr(n: NormalizedNimNode,
         n.errorAst "unexpected node kind in case/if expression"
 
   case n.kind
-  of AtomicNodes, CallNodes, nnkTupleConstr, nnkObjConstr, nnkConv, nnkBracket:
+  of AtomicNodes, CallNodes, ConstructNodes, nnkConv:
     # For calls, conversions, constructions, constants and basic symbols, we
     # just emit the assignment.
     result = transformer(n)

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -100,7 +100,7 @@ func name*(n: IdentDefs): NimNode = n[0]
 
 # fn-VarLetLike
 
-func def(n: VarLetLike): VarLetDef = VarLetDef n.NimNode[0]
+func def*(n: VarLetLike): VarLetDef = VarLetDef n.NimNode[0]
   ## an IdentDefs or VarTuple
 func typ*(n: VarLetLike): NimNode = n.def.typ
   ## the type of this definition (IdentDef or VarTuple)
@@ -171,6 +171,25 @@ proc asVarLetTuple*(n: VarLet): TupleVarLet =
 proc asVarLetIdentDef*(n: VarLet): IdentDefVarLet =
   ## return a IdentDefVarLet if the def is an IdentDef, otherwise error out
   validateAndCoerce(n.NimNode, IdentDefVarLet)
+
+func clone*(n: VarLet, value: NimNode = nil): VarLet =
+  ## clone a `VarLet` but with `value` changed
+  let def = copyNimNode(n.def.NimNode)
+  # copy all nodes in the original definition excluding the last node, which
+  # is the value.
+  for idx in 0 ..< n.def.NimNode.len - 1:
+    def.add copy(n.def.NimNode[idx])
+
+  # add the value replacement
+  # if one is not given we copy the value too
+  if value.isNil:
+    def.add copy(n.def.val)
+  else:
+    def.add copy(value)
+
+  # copy the varlet and add the new def
+  result = expectVarLet:
+    copyNimNode(n.NimNode).add def
 
 # fn-TupleVarLet
 

--- a/cps/returns.nim
+++ b/cps/returns.nim
@@ -13,9 +13,9 @@ proc firstReturn*(p: NimNode): NimNode =
       result = child.firstReturn
       if not result.isNil:
         break
-  of nnkBlockStmt, nnkBlockExpr, nnkFinally:
+  of nnkBlockStmt, nnkBlockExpr, nnkFinally, nnkPragmaBlock:
     result = p.last.firstReturn
-  elif p.isCpsPending or p.isCpsBreak or p.isCpsContinue:
+  elif p.isScopeExit:
     result = p
   else:
     result = nil

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -246,8 +246,8 @@ proc isCpsBlock*(n: NimNode): bool =
   ## `true` if the block `n` contains a cps call anywhere at all;
   ## this is used to figure out if a block needs tailcall handling...
   case n.kind
-  of nnkForStmt, nnkBlockStmt, nnkElse, nnkOfBranch, nnkExceptBranch,
-     nnkFinally:
+  of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkOfBranch,
+     nnkExceptBranch, nnkFinally:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkCaseStmt, nnkWhileStmt,
      nnkElifBranch, nnkTryStmt:

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -45,6 +45,13 @@ const
   ConvNodes* = {nnkHiddenStdConv..nnkConv}
     ## Conversion nodes in typed AST
 
+  AccessNodes* = AtomicNodes + {nnkDotExpr, nnkDerefExpr, nnkHiddenDeref,
+                                nnkAddr, nnkHiddenAddr}
+    ## AST nodes for operations accessing a resource
+
+  ConstructNodes* = {nnkBracket, nnkObjConstr, nnkTupleConstr}
+    ## AST nodes for construction operations
+
 proc getPragmaName(n: NimNode): NimNode =
   ## retrieve the symbol/identifier from the child node of a nnkPragma
   case n.kind
@@ -254,7 +261,7 @@ proc isCpsBlock*(n: NimNode): bool =
      nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
-     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt:
+     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -267,7 +267,12 @@ proc isCpsBlock*(n: NimNode): bool =
     for n in n.items:
       if n.isCpsBlock:
         return true
-  of nnkCallKinds:
-    return n.isCpsCall
+  of CallNodes:
+    if n.isCpsCall:
+      return true
+
+    for n in n.items:
+      if n.isCpsBlock:
+        return true
   else:
     return false

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -251,7 +251,7 @@ proc isCpsBlock*(n: NimNode): bool =
   ## this is used to figure out if a block needs tailcall handling...
   case n.kind
   of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkElseExpr,
-     nnkOfBranch, nnkExceptBranch, nnkFinally:
+     nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
      nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt:

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -258,7 +258,8 @@ proc isCpsBlock*(n: NimNode): bool =
   ## this is used to figure out if a block needs tailcall handling...
   case n.kind
   of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkElseExpr,
-     nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes, nnkExprColonExpr:
+     nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes, nnkExprColonExpr,
+     nnkPragmaBlock:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
      nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket,

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -245,7 +245,7 @@ proc trampoline*[T: Continuation](c: T): T =
 proc isCpsCall*(n: NimNode): bool =
   ## true if this node holds a call to a cps procedure
   if n.len > 0:
-    if n.kind in nnkCallKinds:
+    if n.kind in CallNodes:
       let callee = n[0]
       if not callee.isNil and callee.kind == nnkSym:
         # what we're looking for here is a jumper; it could

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -41,6 +41,10 @@ type
 
   ContinuationProc*[T] = proc(c: T): T {.nimcall.}
 
+const
+  ConvNodes* = {nnkHiddenStdConv..nnkConv}
+    ## Conversion nodes in typed AST
+
 proc getPragmaName(n: NimNode): NimNode =
   ## retrieve the symbol/identifier from the child node of a nnkPragma
   case n.kind

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -246,11 +246,11 @@ proc isCpsBlock*(n: NimNode): bool =
   ## `true` if the block `n` contains a cps call anywhere at all;
   ## this is used to figure out if a block needs tailcall handling...
   case n.kind
-  of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkOfBranch,
-     nnkExceptBranch, nnkFinally:
+  of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkElseExpr,
+     nnkOfBranch, nnkExceptBranch, nnkFinally:
     return n.last.isCpsBlock
-  of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkCaseStmt, nnkWhileStmt,
-     nnkElifBranch, nnkTryStmt:
+  of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
+     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -258,10 +258,11 @@ proc isCpsBlock*(n: NimNode): bool =
   ## this is used to figure out if a block needs tailcall handling...
   case n.kind
   of nnkForStmt, nnkBlockStmt, nnkBlockExpr, nnkElse, nnkElseExpr,
-     nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes:
+     nnkOfBranch, nnkExceptBranch, nnkFinally, ConvNodes, nnkExprColonExpr:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
-     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket:
+     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket,
+     nnkTupleConstr, nnkObjConstr:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -249,8 +249,8 @@ proc isCpsBlock*(n: NimNode): bool =
   of nnkForStmt, nnkBlockStmt, nnkElse, nnkOfBranch, nnkExceptBranch,
      nnkFinally:
     return n.last.isCpsBlock
-  of nnkStmtList, nnkIfStmt, nnkCaseStmt, nnkWhileStmt, nnkElifBranch,
-     nnkTryStmt:
+  of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkCaseStmt, nnkWhileStmt,
+     nnkElifBranch, nnkTryStmt:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -824,7 +824,7 @@ macro cpsManageException(n: typed): untyped =
         # they were equal when it was set by withException.
         #
         # We manually swap the symbol here for because of that.
-        ex[0][1] = cont
+        ex[0][0][1] = cont
 
         # Add the manager itself
         result.body.add:

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -8,34 +8,6 @@ export Continuation, ContinuationProc, cpsCall, cpsMustJump
 when CallNodes - {nnkHiddenCallConv} != nnkCallKinds:
   {.error: "i'm afraid of what you may have become".}
 
-proc isCpsCall(n: NimNode): bool =
-  ## true if this node holds a call to a cps procedure
-  if n.len > 0:
-    if n.kind in nnkCallKinds:
-      let callee = n[0]
-      if not callee.isNil and callee.kind == nnkSym:
-        # what we're looking for here is a jumper; it could
-        # be a magic or it could be another continuation leg
-        # or it could be a completely new continuation
-        result = callee.getImpl.hasPragma("cpsMustJump")
-
-proc isCpsBlock(n: NimNode): bool =
-  ## `true` if the block `n` contains a cps call anywhere at all;
-  ## this is used to figure out if a block needs tailcall handling...
-  case n.kind
-  of nnkForStmt, nnkBlockStmt, nnkElse, nnkOfBranch, nnkExceptBranch,
-     nnkFinally:
-    return n.last.isCpsBlock
-  of nnkStmtList, nnkIfStmt, nnkCaseStmt, nnkWhileStmt, nnkElifBranch,
-     nnkTryStmt:
-    for n in n.items:
-      if n.isCpsBlock:
-        return true
-  of nnkCallKinds:
-    return n.isCpsCall
-  else:
-    return false
-
 proc annotate(parent: var Env; n: NimNode): NimNode
 
 proc makeContProc(name, cont, source: NimNode): NimNode =

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -852,7 +852,7 @@ macro cpsManageException(n: typed): untyped =
   debugAnnotation cpsManageException, n:
     it = it.filter(manage)
 
-proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
+proc cpsTransformProc(T: NimNode, n: NimNode): NimNode =
   ## rewrite the target procedure in Continuation-Passing Style
 
   # keep the original symbol of the proc
@@ -948,3 +948,7 @@ proc cpsTransformProc*(T: NimNode, n: NimNode): NimNode =
   # generated proc bodies, remaining proc, whelp, bootstrap
   result = newStmtList(types, n, whelp, booty)
   result = workaroundRewrites result
+
+macro cpsTransform*(T, n: typed): untyped =
+  ## This is the macro performing the main cps transformation
+  cpsTransformProc(T, n)

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -609,7 +609,8 @@ proc annotate(parent: var Env; n: NimNode): NimNode =
       if i < n.len-1 and nc.isCpsBlock:
 
         case nc.kind
-        of nnkOfBranch, nnkElse, nnkElifBranch, nnkExceptBranch, nnkFinally:
+        of nnkOfBranch, nnkElse, nnkElseExpr, nnkElifBranch, nnkElifExpr,
+           nnkExceptBranch, nnkFinally:
           # these nodes will be handled by their respective parent nodes
           discard
         else:

--- a/tests/taste.nim
+++ b/tests/taste.nim
@@ -430,3 +430,19 @@ suite "tasteful tests":
     foo()
 
     check r == 1
+
+  block:
+    ## splitting within pragma blocks
+    r = 0
+
+    proc foo() {.cps: Cont.} =
+      {.cast(gcsafe).}:
+        noop()
+        inc r
+
+      noop()
+      inc r
+
+    foo()
+
+    check r == 2

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -17,3 +17,18 @@ suite "expression flattening":
       check b == y
 
     foo()
+
+  test "flatten block expression":
+    var k = newKiller(3)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x = block:
+        noop()
+        step 2
+        42
+
+      step 3
+      check x == 42
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -143,3 +143,39 @@ suite "expression flattening":
       step 5
 
     foo()
+
+  test "flatten case matching expression":
+    var k = newKiller(4)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      case (noop(); step 2; "string")
+      of "str":
+        fail "This branch should not be run"
+      of "string":
+        step 3
+      else:
+        fail "This branch should not be run"
+
+      step 4
+
+    foo()
+
+  test "flatten case elif branches":
+    var k = newKiller(4)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      case "string"
+      of "str":
+        fail "This branch should not be run"
+      of "String":
+        fail "This branch should not be run"
+      elif (noop(); step 2; true):
+        step 3
+      else:
+        fail "This branch should not be run"
+
+      step 4
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -125,3 +125,21 @@ suite "expression flattening":
       check x == 42
 
     foo()
+
+  test "flatten if condition":
+    var k = newKiller(5)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      if (noop(); step 2; false):
+        fail "This branch should not be run"
+      elif (noop(); step 3; true):
+        step 4
+      elif (noop(); fail"This expression should not be evaluated"; false):
+        fail "This branch should not be run"
+      else:
+        fail "This branch should not be run"
+
+      step 5
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -69,3 +69,32 @@ suite "expression flattening":
       check y == 30
 
     foo()
+
+  test "flatten case expression":
+    var k = newKiller(3)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x =
+        case "true"
+        of "truer", "truest", "very true":
+          fail "this branch should not run"
+          0
+        of "false":
+          fail "this branch should not run"
+          -1
+        of "true":
+          noop()
+          step 2
+          42
+        elif true:
+          fail "this branch should not run"
+          -3
+        else:
+          fail "this branch should not run"
+          -2
+
+      step 3
+      check x == 42
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -32,3 +32,40 @@ suite "expression flattening":
       check x == 42
 
     foo()
+
+  test "flatten if expression":
+    var k = newKiller(5)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x =
+        if true:
+          noop()
+          step 2
+          42
+        elif true:
+          fail "this branch should not run"
+          0 # needed because the compiler doesn't recognize fail as noreturn
+        else:
+          fail "this branch should not run"
+          -1 # needed because the compiler doesn't recognize fail as noreturn
+
+      step 3
+      check x == 42
+
+      let y =
+        if false:
+          fail "this branch should not run"
+          -1
+        elif false:
+          fail "this branch should not run"
+          0
+        else:
+          noop()
+          step 4
+          30
+
+      step 5
+      check y == 30
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -382,3 +382,37 @@ suite "expression flattening":
       check x == [1, 2, 42, 10, 20]
 
     foo()
+
+  test "flatten tuple construction":
+    var k = newKiller(5)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x = (a: 1, b: 2, c: (step 2; 42), d: (noop(); step 3; 10), e: (step 4; 20))
+
+      step 5
+      # A few checks to verify that the names stay
+      check x.a == 1
+      check x.b == 2
+      check x == (1, 2, 42, 10, 20)
+
+    foo()
+
+  test "flatten object construction":
+    type
+      O = object of RootObj
+        x: int
+        y: int
+        z: float
+
+    var k = newKiller(5)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x = O(x: (step 2; 42), y: (noop(); step 3; 10), z: (step 4; 20))
+
+      step 5
+      # A few checks to verify that the names stay
+      check x == O(x: 42, y: 10, z: 20)
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -451,3 +451,16 @@ suite "expression flattening":
       check (noop(); step 7; true) or (noop(); fail "this should not run"; false)
 
     foo()
+
+  test "flatten raise statement":
+    var k = newKiller(3)
+
+    proc foo() {.cps: Cont.} =
+      step 1
+      try:
+        raise (noop(); step 2; newException(CatchableError, "test"))
+      except CatchableError as e:
+        step 3
+        check e.msg == "test"
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -352,3 +352,21 @@ suite "expression flattening":
       check i == 42
 
     foo()
+
+  test "flatten discard statements":
+    var k = newKiller(3)
+    proc foo() {.cps: Cont.} =
+      step 1
+      discard (block: (noop(); step 2; 42.Natural))
+
+      step 3
+
+    foo()
+
+  test "flatten return statements":
+    var k = newKiller(2)
+    proc foo(): int {.cps: Cont.} =
+      step 1
+      return (block: (noop(); step 2; 42.Natural))
+
+    check foo() == 42

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -179,3 +179,16 @@ suite "expression flattening":
       step 4
 
     foo()
+
+  test "flatten while condition":
+    var k = newKiller(4)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      var x = 2
+      while (noop(); step x; inc x; x < 4):
+        discard
+
+      step 4
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -370,3 +370,15 @@ suite "expression flattening":
       return (block: (noop(); step 2; 42.Natural))
 
     check foo() == 42
+
+  test "flatten array construction":
+    var k = newKiller(5)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x = [1, 2, (step 2; 42), (noop(); step 3; 10), (step 4; 20)]
+
+      step 5
+      check x == [1, 2, 42, 10, 20]
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -1,0 +1,19 @@
+include preamble
+
+import killer
+
+suite "expression flattening":
+  test "flatten expression list in var/let":
+    var k = newKiller(3)
+    proc foo() {.cps: Cont.} =
+      let
+        x = (noop(); step 1; 42)
+        y = (noop(); step 2; x)
+
+      check x == y
+
+      var (a, b) = (noop(); step 3; (10, y))
+      check a == 10
+      check b == y
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -98,3 +98,30 @@ suite "expression flattening":
       check x == 42
 
     foo()
+
+  test "flatten try statement":
+    var k = newKiller(4)
+    proc foo() {.cps: Cont.} =
+      step 1
+
+      let x =
+        try:
+          raise newException(ValueError, "something")
+          0
+        except ValueError, IOError:
+          noop()
+          let e = getCurrentException()
+          check e of ValueError
+          check e.msg == "something"
+          step 2
+          42
+        except:
+          fail "this branch should not run"
+          -1
+        finally:
+          step 3
+
+      step 4
+      check x == 42
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -416,3 +416,38 @@ suite "expression flattening":
       check x == O(x: 42, y: 10, z: 20)
 
     foo()
+
+  test "flatten calls":
+    var k = newKiller(5)
+
+    proc bar(a, b: int) =
+      step 3
+      check a == 42
+      check b == 10
+
+    proc barvar(a: var int, b: int) =
+      step 5
+      check a == 20
+      check b == 20
+
+    proc foo() {.cps: Cont.} =
+      step 1
+      var x = 42
+      bar(x, (noop(); step 2; x = 10; x))
+
+      x = 42
+      barvar(x, (noop(); step 4; x = 20; x))
+
+    foo()
+
+  test "flatten and/or with short circuiting":
+    var k = newKiller(7)
+
+    proc foo() {.cps: Cont.} =
+      step 1
+      check (noop(); step 2; true) and (noop(); step 3; true)
+      check not((noop(); step 4; false) and (noop(); fail "this should not run"; true))
+      check (noop(); step 5; false) or (noop(); step 6; true)
+      check (noop(); step 7; true) or (noop(); fail "this should not run"; false)
+
+    foo()


### PR DESCRIPTION
To enable CPS to transform expressions like:

```nim
let x =
  if true:
    noop()
    1
  else:
    -1
```

This PR implements a pass that rewrites expressions into statements, the example above would become:

```nim
var :tmp: int
if true:
  noop()
  :tmp = 1
else:
  :tmp = -1

let x = :tmp
```

Allow CPS to transform as normal.

What really happens here is that we encode the control flow into the AST (ie. the `if` has to be run before `x` is declared).

Checklist:
- [x] Rewrite complex expression to assignment
  - [x] Expression list
  - [x] Block expression
  - [x] If expression
  - [x] Case expression
  - [x] Try expression
- [x] Rewrite complex expressions in
  - [x] Let/Var section
  - [x] Assignments
  - [x] While condition
  - [x] If condition
  - [x] Case matching expression
  - [x] Call parameters
  - [x] Conversion (simpler than call since it's side-effect free and can be applied directly to the expression)
  - [x] Array construction
  - [x] Object construction
  - [x] Tuple construction
  - [x] `and`/`or` boolean operators
  - [x] Discard statement
  - [x] Return statement
  - [x] Raise statement

Let me know if I miss any potential places

Closes #126