### PR TITLE
move State and bind it for `()`

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -1,6 +1,6 @@
 import std/[macros]
 import cps/[spec, transform, rewrites, hooks, exprs]
-export Continuation, ContinuationProc
+export Continuation, ContinuationProc, State
 export cpsCall, cpsMagicCall, cpsVoodooCall, cpsMustJump
 
 # exporting some symbols that we had to bury for bindSym reasons
@@ -17,35 +17,28 @@ when not defined(nimPanics):
   {.warning: "cps supports --panics:on only; " &
              " see https://github.com/disruptek/cps/issues/110".}
 
-type
-  State* {.pure.} = enum
-    ## Representation of the state of a continuation.
-    Running    ## The continuation is active and running and can be resumed
-    Dismissed  ## The continuation is currently somewhere else
-    Finished   ## The continuation is finished and can no longer be resumed
-
 proc state*(c: Continuation): State =
   ## Get the current state of a continuation
   if c == nil:
-    Dismissed
+    State.Dismissed
   elif c.fn == nil:
-    Finished
+    State.Finished
   else:
-    Running
+    State.Running
 
 {.push hint[ConvFromXtoItselfNotNeeded]: off.}
 
 template running*(c: Continuation): bool =
   ## `true` if the continuation is running.
-  (Continuation c).state == Running
+  (Continuation c).state == State.Running
 
 template finished*(c: Continuation): bool =
   ## `true` if the continuation is finished.
-  (Continuation c).state == Finished
+  (Continuation c).state == State.Finished
 
 template dismissed*(c: Continuation): bool =
   ## `true` if the continuation was dimissed.
-  (Continuation c).state == Dismissed
+  (Continuation c).state == State.Dismissed
 
 {.pop.}
 

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -436,15 +436,9 @@ proc createResult*(env: Env, exported = false): ProcDef =
   if exported:
     name = postfix(name, "*")
 
-  # we bind these here so that they won't clash elsewhere
-  let
-    dismissed = bindSym"Dismissed"
-    finished = bindSym"Finished"
-    running = bindSym"Running"
-
   result = ProcDef:
-    genAst(name, field, dismissed, finished, running,
-           c = env.first, cont = env.identity, tipe = env.rs.typ):
+    genAst(name, field, c = env.first, cont = env.identity, tipe = env.rs.typ,
+           dismissed=Dismissed, finished=Finished, running=Running):
       {.push experimental: "callOperator".}
       proc name(c: cont): tipe {.used.} =
         case c.state

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -436,17 +436,24 @@ proc createResult*(env: Env, exported = false): ProcDef =
   if exported:
     name = postfix(name, "*")
 
+  # we bind these here so that they won't clash elsewhere
+  let
+    dismissed = bindSym"Dismissed"
+    finished = bindSym"Finished"
+    running = bindSym"Running"
+
   result = ProcDef:
-    genAst(name, field, c = env.first, cont = env.identity, tipe = env.rs.typ):
+    genAst(name, field, dismissed, finished, running,
+           c = env.first, cont = env.identity, tipe = env.rs.typ):
       {.push experimental: "callOperator".}
       proc name(c: cont): tipe {.used.} =
         case c.state
-        of Dismissed:
+        of dismissed:
           raise Defect.newException:
             "dismissed continuations have no result"
-        of Finished:
+        of finished:
           field
-        of Running:
+        of running:
           `()`(trampoline c)
       {.pop.}
 

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -323,3 +323,10 @@ proc enbasen*(n: NimNode): NimNode =
     enbasen: getImpl n
   else:
     n
+
+type
+  State* {.pure.} = enum
+    ## Representation of the state of a continuation.
+    Running    ## The continuation is active and running and can be resumed
+    Dismissed  ## The continuation is currently somewhere else
+    Finished   ## The continuation is finished and can no longer be resumed

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -47,12 +47,12 @@ suite "cps api":
     check "whelp initial state surprised us":
       not c.dismissed
       not c.finished
-      c.state == Running
+      c.state == State.Running
       c.running
     trampoline c
     check "whelp state after trampoline surprised us":
       not c.dismissed
-      c.state == Finished
+      c.state == State.Finished
       c.finished
       not c.running
 


### PR DESCRIPTION
This solves a clash in eventqueue between `Event.Finished` and `State.Finished` inside our generated `()`.