### PR TITLE
implements dot expression, addr, deref and magic calls flattening

### DIFF
--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -78,9 +78,9 @@ func filterExpr[T: NormNode](n: T, transformer: proc(n: T): T): T =
       result = n.errorAst "unexpected node kind in case/if expression"
 
   case n.kind
-  of AtomicNodes, CallNodes, ConstructNodes, nnkConv, nnkBracketExpr:
-    # For calls, conversions, constructions, constants and basic symbols, we
-    # just emit the assignment.
+  of AccessNodes, CallNodes, ConstructNodes, nnkConv:
+    # For calls, conversions, constructions, constants, basic symbols, field
+    # access, we just emit the assignment.
     result = transformer(n)
   of nnkStmtList, nnkStmtListExpr:
     result = copyNodeAndTransformIt(n):
@@ -162,12 +162,6 @@ func filterExpr[T: NormNode](n: T, transformer: proc(n: T): T): T =
     ## Hidden conversion nodes can be reconstructed by the compiler if needed,
     ## so we just skip them and rewrite the body instead.
     result = filterExpr(n.last, transformer)
-  of nnkDotExpr:
-    ## this is either the first expr we encountered or we were passed this and
-    ## so we treat it as a terminal operation regardless
-    ##
-    ## see https://github.com/disruptek/cps/issues/211).
-    result = transformer(n)
   else:
     result = n.errorAst "cps doesn't know how to rewrite this into assignment"
 

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -603,14 +603,12 @@ func annotate(n: NormNode): NormNode =
         result.add:
           # Lift the inner expression out
           newCall(bindName"cpsExprLifter"):
-            # FIXME: @saem please show me how to remove this
-            NormNode:
-              # Create an explicit deref node with lineinfo copied from the original
-              newNimNode(nnkDerefExpr, child).add:
-                # Rewrite the inner CPS expression into a temporary
-                newCall(bindName"cpsExprToTmp", getTypeInst(child[0])):
-                  newStmtList:
-                    annotate child[0]
+            # Create an explicit deref node with lineinfo copied from the original
+            newNimNode(nnkDerefExpr, child).add:
+              # Rewrite the inner CPS expression into a temporary
+              newCall(bindName"cpsExprToTmp", getTypeInst(child[0])):
+                newStmtList:
+                  annotate child[0]
 
       of AccessNodes - AtomicNodes - HiddenNodes - {nnkDotExpr}, ConstructNodes, CallNodes:
         let magic = child.getMagic

--- a/cps/exprs.nim
+++ b/cps/exprs.nim
@@ -650,6 +650,14 @@ func annotate(n: NormNode): NormNode =
                   nnkElse.newTree(child[2])
                 )
 
+        elif magic == "Addr":
+          # We can't handle this stuff since the semantics of addr is undefined
+          #
+          # See leorize's analysis:
+          # https://matrix.to/#/!WkVPhTZzbUBGGVSkoK:matrix.org/$SUfctUKcYXLRyTiot4TqNuSCBkLBpA5Xt6qauceoTQ0?via=libera.chat&via=matrix.org&via=envs.net
+          result.add:
+            child.errorAst("Obtaining the address of a CPS expression is not supported")
+
         else:
           # For these nodes, the evaluation order of each child is the same
           # as their order in the AST.

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -183,7 +183,8 @@ const TypeExprKinds = {
 
 func errorGot(msg: string, n: NimNode, got: string = treeRepr(n)) =
   ## useful for error messages
-  error msg & ", got:\n" & repr(got), n
+  {.cast(noSideEffect).}:
+    error msg & ", got:\n" & repr(got), n
 
 func errorGot*(msg: string, n: NormNode, got: string = treeRepr(n.NimNode)) =
   ## useful for error messages

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -1075,8 +1075,8 @@ proc newProcDef*(name: Name, retType: TypeExpr,
   ## create a new proc def with name, returnt type, and calling params and an
   ## empty body (`nnkStmtList`)
   var formalParams = @[NimNode retType]
-  formalParams = formalParams & seq[NimNode] @callParams
-  newProc(name.Nimnode, formalParams, newStmtList()).ProcDef
+  formalParams.add seq[NimNode](@callParams)
+  newProc(name.NimNode, formalParams, newStmtList()).ProcDef
 
 createAsTypeFunc(ProcDef, {nnkProcDef}, "node is not a proc definition")
 

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -210,8 +210,8 @@ const
   ConvNodes* = {nnkHiddenStdConv..nnkConv}
     ## Conversion nodes in typed AST
 
-  AccessNodes* = AtomicNodes + {nnkDotExpr, nnkDerefExpr, nnkHiddenDeref,
-                                nnkAddr, nnkHiddenAddr}
+  AccessNodes* = AtomicNodes + {nnkBracketExpr, nnkDotExpr, nnkDerefExpr,
+                                nnkHiddenDeref, nnkAddr, nnkHiddenAddr}
     ## AST nodes for operations accessing a resource
 
   ConstructNodes* = {nnkBracket, nnkObjConstr, nnkTupleConstr}

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -211,7 +211,7 @@ const
     ## Conversion nodes in typed AST
 
   AccessNodes* = AtomicNodes + {nnkBracketExpr, nnkDotExpr, nnkDerefExpr,
-                                nnkHiddenDeref, nnkAddr, nnkHiddenAddr}
+                                nnkHiddenDeref, nnkHiddenAddr}
     ## AST nodes for operations accessing a resource
 
   ConstructNodes* = {nnkBracket, nnkObjConstr, nnkTupleConstr}

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -577,6 +577,12 @@ func isNil*(n: TypeExpr): bool {.borrow.}
 proc `==`*(a, b: TypeExpr): bool {.borrow.}
   ## compare two `TypeEpxr`s and see if they're equal
 
+proc typeKind*(n: TypeExpr): NimTypeKind {.borrow.}
+  ## get the type kind of a type expr
+
+proc sameType*(a, b: TypeExpr): bool {.borrow.}
+  ## compare the type associated with the `TypeExpr`s and see if they're equal
+
 # fn-TypeExprObj
 
 createAsTypeFunc(TypeExprObj, {nnkObjectTy}, "not an object type expression")

--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -217,6 +217,10 @@ const
   ConstructNodes* = {nnkBracket, nnkObjConstr, nnkTupleConstr}
     ## AST nodes for construction operations
 
+  HiddenNodes* = {nnkHiddenCallConv, nnkHiddenStdConv, nnkHiddenSubConv,
+                  nnkHiddenAddr, nnkHiddenDeref}
+    ## "Hidden" AST nodes
+
 # Converters - to reduce the conversion spam
 
 macro defineToNimNodeConverter(ts: varargs[typed]) =

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -221,9 +221,8 @@ proc isCpsBlock*(n: NormNode): bool =
      nnkPragmaBlock, nnkIdentDefs, nnkVarSection, nnkLetSection:
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
-     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket,
-     nnkBracketExpr, nnkTupleConstr, nnkObjConstr, nnkAsgn, nnkVarTuple,
-     nnkDotExpr:
+     nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkAsgn,
+     nnkVarTuple, AccessNodes - AtomicNodes, ConstructNodes:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -222,7 +222,8 @@ proc isCpsBlock*(n: NormNode): bool =
     return n.last.isCpsBlock
   of nnkStmtList, nnkStmtListExpr, nnkIfStmt, nnkIfExpr, nnkCaseStmt,
      nnkWhileStmt, nnkElifBranch, nnkElifExpr, nnkTryStmt, nnkBracket,
-     nnkBracketExpr, nnkTupleConstr, nnkObjConstr, nnkAsgn, nnkVarTuple:
+     nnkBracketExpr, nnkTupleConstr, nnkObjConstr, nnkAsgn, nnkVarTuple,
+     nnkDotExpr:
     for n in n.items:
       if n.isCpsBlock:
         return true

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -497,3 +497,15 @@ suite "expression flattening":
       check (noop(); step 1; [42])[(noop(); step 2; 0)] == 42
 
     foo()
+
+  test "flatten dot expressions":
+    type
+      P = object
+        val: int
+    var k = newKiller(1)
+    proc foo(p: P): int {.cps: Cont.} =
+      noop()
+      step 1
+      p.val
+
+    check foo(P(val: 42)) == 42

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -509,3 +509,27 @@ suite "expression flattening":
       check (noop(); step 1; P(val: 42)).val == 42
 
     foo()
+
+  test "flatten dereference expressions":
+    type
+      P = ref object
+        val: int
+
+    var k = newKiller(1)
+
+    proc foo() {.cps: Cont.} =
+      check (noop(); step 1; P(val: 42))[].val == 42
+
+    foo()
+
+  test "flatten hidden dereference expressions":
+    type
+      P = ref object
+        val: int
+
+    var k = newKiller(1)
+
+    proc foo() {.cps: Cont.} =
+      check (noop(); step 1; P(val: 42)).val == 42
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -502,10 +502,10 @@ suite "expression flattening":
     type
       P = object
         val: int
-    var k = newKiller(1)
-    proc foo(p: P): int {.cps: Cont.} =
-      noop()
-      step 1
-      p.val
 
-    check foo(P(val: 42)) == 42
+    var k = newKiller(1)
+
+    proc foo() {.cps: Cont.} =
+      check (noop(); step 1; P(val: 42)).val == 42
+
+    foo()

--- a/tests/texprs.nim
+++ b/tests/texprs.nim
@@ -533,3 +533,21 @@ suite "expression flattening":
       check (noop(); step 1; P(val: 42)).val == 42
 
     foo()
+
+  test "flatten magic calls with mutable variables":
+    var k = newKiller(3)
+
+    proc foo() {.cps: Cont.} =
+      var x: string
+      # add(var string, string) is a magic
+      x.add (noop(); step 1; "test")
+      check x == "test"
+
+      var y: seq[string]
+      # add(var seq[T], T) is a magic with generics
+      y.add (noop(); step 2; "test")
+      check y == @["test"]
+
+      step 3
+
+    foo()

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -26,14 +26,30 @@ suite "returns and results":
 
   block:
     ## continuations can return values via bootstrap
-    var k = newKiller 1
-    proc foo(x: int): int {.cps: Cont.} =
-      noop()
-      step 1
-      return x * x
+    block:
+      var k = newKiller 1
+      proc foo(x: int): int {.cps: Cont.} =
+        noop()
+        step 1
+        return x * x
 
-    let x = foo(3)
-    check x == 9
+      let x = foo(3)
+      check x == 9
+
+    block:
+      ## implicit return values via bootstrap
+      type
+        P = object
+          val: int
+
+      var k = newKiller 1
+      proc foo(p: P): int {.cps: Cont.} =
+        noop()
+        step 1
+        p.val
+
+      let x = foo(P())
+      check x == 0
 
   block:
     ## continuations can return values via whelp

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -26,30 +26,14 @@ suite "returns and results":
 
   block:
     ## continuations can return values via bootstrap
-    block:
-      var k = newKiller 1
-      proc foo(x: int): int {.cps: Cont.} =
-        noop()
-        step 1
-        return x * x
+    var k = newKiller 1
+    proc foo(x: int): int {.cps: Cont.} =
+      noop()
+      step 1
+      return x * x
 
-      let x = foo(3)
-      check x == 9
-
-    block:
-      ## implicit return values via bootstrap
-      type
-        P = object
-          val: int
-
-      var k = newKiller 1
-      proc foo(p: P): int {.cps: Cont.} =
-        noop()
-        step 1
-        p.val
-
-      let x = foo(P())
-      check x == 0
+    let x = foo(3)
+    check x == 9
 
   block:
     ## continuations can return values via whelp


### PR DESCRIPTION
Summary:
- Implements `expr().b` flattening
- Implements `expr()[]` flattening
- ~~Error on `addr expr()`~~ Implements `var T` support for `{.magic.}` calls

Supersede and closes #213 

Fixes #211 
Fixes #207 