### PR TITLE
rewrite return then annotate

### DIFF
--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -352,7 +352,7 @@ proc localSection*(e: var Env; n: RoutineParam; into: NimNode = nil) {.borrow.}
   ## consume proc definition params and yield name, node pairs representing
   ## assignments to local scope.
 
-proc rewriteReturn*(e: var Env; n: NimNode): NimNode =
+proc rewriteReturn*(e: var Env; n: NormNode): NormNode =
   ## Rewrite a return statement to use our result field.
   if n.len != 1:
     result = n.errorAst "return len != 1"

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -730,8 +730,8 @@ proc annotate(parent: var Env; n: NormNode): NormNode =
       # return statement without regard to the contents of `result`
       # because it may hold, eg. `ElifBranch ...` or similar.
       result.add:
-        env.rewriteReturn:
-          env.annotate nc
+        env.annotate:
+          env.rewriteReturn nc
       endAndReturn()
 
     of nnkVarSection, nnkLetSection:

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -149,3 +149,15 @@ suite "returns and results":
       step 2
 
     foo()
+
+  block:
+    ## returning a continuation return value works
+    var k = newKiller(1)
+    proc bar(): string {.cps: Cont.} =
+      step 1
+      result = "test"
+
+    proc foo(): string {.cps: Cont.} =
+      return bar()
+
+    check foo() == "test"


### PR DESCRIPTION
We are rewriting return to assignment to result, so run annotate after
that so it could cover "assign with cps call"

Fixes #219 