### PR TITLE
call with the continuation's type instead of the magic type

### DIFF
--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -532,8 +532,7 @@ proc rewriteVoodoo*(env: Env; n: NormNode): NormNode =
     if n.isVoodooCall:
       let it = asCall n.copyNimTree
       # https://github.com/nim-lang/Nim/issues/18365
-      let contType = pragmaArgument(it.impl, "cpsUserType")
-      it.prependArg newCall(contType, env.first)
+      it.prependArg newCall(env.inherits, env.first)
       desym it
       result = it
   result = filter(n, voodoo)

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -532,7 +532,7 @@ proc rewriteVoodoo*(env: Env; n: NormNode): NormNode =
     if n.isVoodooCall:
       let it = asCall n.copyNimTree
       # https://github.com/nim-lang/Nim/issues/18365
-      it.prependArg newCall(env.inherits, env.first)
+      it.prependArg newCall(env.root, env.first)
       desym it
       result = it
   result = filter(n, voodoo)

--- a/cps/returns.nim
+++ b/cps/returns.nim
@@ -101,7 +101,6 @@ proc jumperCall*(cont, contType, to: Name; via: NormNode): NormNode =
   # we may need to insert an argument if the call is magical
   if jump.impl.hasPragma "cpsMagicCall":
     # https://github.com/nim-lang/Nim/issues/18365
-    let contType = pragmaArgument(jump.impl, "cpsUserType")
     jump.prependArg newCall(contType, cont)
   # we need to desym the jumper; it is currently sem-ed to the
   # variant that doesn't take a continuation.

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -19,7 +19,6 @@ template cpsMagicCall*() {.pragma.}     ## a cps call
 template cpsVoodooCall*() {.pragma.}    ## a voodoo call
 template cpsMustJump*() {.pragma.}      ## cps calls and magic calls jump
 template cpsPending*() {.pragma.}       ## this is the last continuation
-template cpsUserType*(tipe: typed) {.pragma.} ## to recover Cont from a magic
 template cpsBreak*(label: typed = nil) {.pragma.} ##
 ## this is a break statement in a cps block
 template cpsContinue*() {.pragma.}      ##
@@ -360,10 +359,6 @@ proc makeErrorShim*(n: NimNode): NimNode =
   # value.  While this version will throw an exception at runtime, it
   # may be used inside CPS as magic(); for better programmer ergonomics.
   var shim = copyNimTree n
-  # stash the type of the first argument into a pragma so we can use it
-  # when converting the continuation to the proper magic call inside cps
-  shim.addPragma:
-    bindSym"cpsUserType".colon shim.params[1][1]
   del(shim.params, 1)               # delete the 1st Continuation argument
   let msg = newLit($n.name & "() is only valid in {.cps.} context")
   shim.body =                       # raise a defect when invoked directly

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -148,3 +148,67 @@ suite "cps api":
       step 3
 
     foo()
+
+  block:
+    ## calling magic that is not defined for the base type should not compile
+    skip "FIXME: Figure out a way to test compile-time failures":
+      type AnotherCont = ref object of Continuation
+      proc magic(c: AnotherCont): AnotherCont {.cpsMagic.} = discard
+
+      proc foo() {.cps: Cont.} =
+        magic()
+
+  block:
+    ## calling magic/voodoo with generics continuation parameter works
+    # XXX: Not sure why, but Killer doesn't work here, complaining about
+    #      `k` not in scope.
+    var r = 0
+
+    type AnotherCont = ref object of Continuation
+    proc magic(c: Cont or AnotherCont): auto {.cpsMagic.} =
+      inc r
+      c
+
+    proc voodoo(c: Cont or AnotherCont) {.cpsVoodoo.} =
+      inc r
+
+    proc foo() {.cps: Cont.} =
+      inc r
+      voodoo()
+      magic()
+
+    foo()
+    check r == 3
+
+  # Not using block here since using can only be used on the top-level
+  using c: Cont
+
+  block:
+    ## magic/voodoo can be defined with `using`
+    var k = newKiller 4
+
+    proc magic(c): Cont {.cpsMagic.} =
+      step 2
+      check not c.dismissed, "continuation was dismissed"
+      check not c.finished, "continuation was finished"
+      result = c
+
+    proc voodoo(c): int {.cpsVoodoo.} =
+      step 3
+      check not c.dismissed, "continuation was dismissed"
+      check not c.finished, "continuation was finished"
+      result = 2
+
+    proc foo(): int {.cps: Cont.} =
+      noop()
+      step 1
+      check k.step == 1, "right"
+      magic()
+      check k.step == 2, "magic failed to run"
+      noop()
+      check voodoo() == 2, "voodoo failed to yield 2"
+      noop()
+      step 4
+      return 3
+
+    check foo() == 3

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -179,35 +179,34 @@ suite "cps api":
     foo()
     check r == 3
 
-  # Not using block here since using can only be used on the top-level
-  using c: Cont
-
   block:
     ## magic/voodoo can be defined with `using`
-    var k = newKiller 4
+    skip "`using` can only be used on top-level, and if it is, balls fails the test in debug mode":
+      using c: Cont
+      var k = newKiller 4
 
-    proc magic(c): Cont {.cpsMagic.} =
-      step 2
-      check not c.dismissed, "continuation was dismissed"
-      check not c.finished, "continuation was finished"
-      result = c
+      proc magic(c): Cont {.cpsMagic.} =
+        step 2
+        check not c.dismissed, "continuation was dismissed"
+        check not c.finished, "continuation was finished"
+        result = c
 
-    proc voodoo(c): int {.cpsVoodoo.} =
-      step 3
-      check not c.dismissed, "continuation was dismissed"
-      check not c.finished, "continuation was finished"
-      result = 2
+      proc voodoo(c): int {.cpsVoodoo.} =
+        step 3
+        check not c.dismissed, "continuation was dismissed"
+        check not c.finished, "continuation was finished"
+        result = 2
 
-    proc foo(): int {.cps: Cont.} =
-      noop()
-      step 1
-      check k.step == 1, "right"
-      magic()
-      check k.step == 2, "magic failed to run"
-      noop()
-      check voodoo() == 2, "voodoo failed to yield 2"
-      noop()
-      step 4
-      return 3
+      proc foo(): int {.cps: Cont.} =
+        noop()
+        step 1
+        check k.step == 1, "right"
+        magic()
+        check k.step == 2, "magic failed to run"
+        noop()
+        check voodoo() == 2, "voodoo failed to yield 2"
+        noop()
+        step 4
+        return 3
 
-    check foo() == 3
+      check foo() == 3

--- a/tests/tapi.nim
+++ b/tests/tapi.nim
@@ -107,7 +107,6 @@ suite "cps api":
 
   block:
     ## accessing exported continuation's result from a continuation works
-    skip"later"
     var k = newKiller 2
     proc foo() {.cps: Cont.} =
       step 1


### PR DESCRIPTION
The fix to hooks in #230 solved the issue of getting the user type in other phases, as such we no longer
need to extract it from magic/voodoo implementation.

Fixes #233 and a few more scenario with magics.